### PR TITLE
feat: "not_defined" instead of "draft" - Project Form

### DIFF
--- a/web/frontend/src/actions/projects/postProject.ts
+++ b/web/frontend/src/actions/projects/postProject.ts
@@ -9,7 +9,12 @@ export interface PostProjectRequest {
   city: string;
   neighborhood: string;
   street: string;
-  phase: "preliminary_study" | "draft" | "basic_project" | "executive_project" | "released_for_construction";
+  phase:
+    | "preliminary_study"
+    | "not_defined"
+    | "basic_project"
+    | "executive_project"
+    | "released_for_construction";
   description?: string | undefined;
   image_url?: string | undefined;
 }

--- a/web/frontend/src/components/layout/drawer-form-project.tsx
+++ b/web/frontend/src/components/layout/drawer-form-project.tsx
@@ -73,7 +73,7 @@ export default function DrawerFormProject({
       city: projectData?.city || "",
       neighborhood: projectData?.neighborhood || "",
       cep: projectData?.cep || "",
-      phase: projectData?.phase || "preliminary_study",
+      phase: projectData?.phase || "not_defined",
       street: projectData?.street || "",
       number: projectData?.number || "",
       image_url: undefined,
@@ -229,7 +229,7 @@ export default function DrawerFormProject({
           city: projectData.city || "",
           neighborhood: projectData.neighborhood || "",
           cep: projectData.cep || "",
-          phase: projectData.phase || "preliminary_study",
+          phase: projectData.phase || "not_defined",
           street: projectData.street || "",
           number: projectData.number || "",
           image_url: undefined,
@@ -242,7 +242,7 @@ export default function DrawerFormProject({
           city: "",
           neighborhood: "",
           cep: "",
-          phase: "preliminary_study",
+          phase: "not_defined",
           street: "",
           number: "",
           image_url: undefined,
@@ -466,11 +466,11 @@ export default function DrawerFormProject({
                         />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value="not_defined">
+                          {t("common.projectPhaseOptions.not_defined")}
+                        </SelectItem>
                         <SelectItem value="preliminary_study">
                           {t("common.projectPhaseOptions.preliminary_study")}
-                        </SelectItem>
-                        <SelectItem value="draft">
-                          {t("common.projectPhaseOptions.draft")}
                         </SelectItem>
                         <SelectItem value="basic_project">
                           {t("common.projectPhaseOptions.basic_project")}

--- a/web/frontend/src/i18n/locales/en/translation.json
+++ b/web/frontend/src/i18n/locales/en/translation.json
@@ -7,7 +7,7 @@
     "constructiveTechnology": "Constructive Technology",
     "projectPhaseOptions": {
       "preliminary_study": "Preliminary Study",
-      "draft": "Draft",
+      "not_defined": "Not defined",
       "basic_project": "Basic Project",
       "executive_project": "Executive Project",
       "released_for_construction": "Released for Construction"

--- a/web/frontend/src/i18n/locales/es/translation.json
+++ b/web/frontend/src/i18n/locales/es/translation.json
@@ -7,7 +7,7 @@
     "constructiveTechnology": "Módulo",
     "projectPhaseOptions": {
       "preliminaryStudy": "Estudio Preliminar",
-      "draft": "Borrador",
+      "not_defined": "No Definido",
       "basicProject": "Proyecto Básico",
       "executiveProject": "Proyecto Ejecutivo",
       "releasedForConstruction": "Liberado para Construcción"

--- a/web/frontend/src/i18n/locales/ptbr/translation.json
+++ b/web/frontend/src/i18n/locales/ptbr/translation.json
@@ -6,7 +6,7 @@
     "constructiveTechnology": "Módulo de Tecnologia Construtiva",
     "projectPhaseOptions": {
       "preliminary_study": "Estudo Preliminar",
-      "draft": "Não definido",
+      "not_defined": "Não definido",
       "basic_project": "Projeto Básico",
       "executive_project": "Projeto Executivo",
       "released_for_construction": "Liberado para Obra"

--- a/web/frontend/src/types/projects.ts
+++ b/web/frontend/src/types/projects.ts
@@ -5,7 +5,7 @@ import { TUnitType } from "./units";
 
 export type TProjectPhase =
   | "preliminary_study"
-  | "draft"
+  | "not_defined"
   | "basic_project"
   | "executive_project"
   | "released_for_construction";

--- a/web/frontend/src/validators/projectForm.validador.ts
+++ b/web/frontend/src/validators/projectForm.validador.ts
@@ -16,7 +16,7 @@ export const projectFormSchema = z.object({
   number: z.string().min(1, "O número deve ser informado").optional(),
   phase: z.enum(
     [
-      "draft",
+      "not_defined",
       "preliminary_study",
       "basic_project",
       "executive_project",


### PR DESCRIPTION
This pull request introduces changes to replace the "draft" project phase with a new "not_defined" phase across the frontend codebase. This update ensures consistency in project phase handling and improves clarity for undefined project states. The changes span type definitions, default values, UI components, and translations.

### Updates to project phase handling:

* **Type Definitions**:
  - Updated the `TProjectPhase` type in `web/frontend/src/types/projects.ts` to replace "draft" with "not_defined".
  - Modified the `PostProjectRequest` interface in `web/frontend/src/actions/projects/postProject.ts` to include "not_defined" and remove "draft".

* **Default Values**:
  - Replaced default "draft" phase with "not_defined" in multiple locations within the `DrawerFormProject` component. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L76-R76) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L232-R232) [[3]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L245-R245)

* **UI Components**:
  - Updated the project phase dropdown in `DrawerFormProject` to include "not_defined" and removed "draft".

* **Validation**:
  - Adjusted the project form schema in `web/frontend/src/validators/projectForm.validador.ts` to validate "not_defined" instead of "draft".

* **Translations**:
  - Updated translations in `translation.json` files for English, Spanish, and Portuguese to reflect the new "not_defined" phase and remove "draft". [[1]](diffhunk://#diff-7be25939b340100d8d1a98dfb1e29905fc9e34967bb90a18369f7ef461e87991L10-R10) [[2]](diffhunk://#diff-13f54793b792b2a92a7628f6e825e9d40a15ed7ea073716d05c2f1a008385558L10-R10) [[3]](diffhunk://#diff-949116272053394c578a9e04a036f15c3be3ebcd543eb63cd5eca241dd577ce9L9-R9)