### PR TITLE
feat: filter 'floors' to project benchmark

### DIFF
--- a/cmd/api/benchmark.go
+++ b/cmd/api/benchmark.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"sort"
 
@@ -123,6 +124,7 @@ func (app *application) getProjectsBenchmarkHandler(w http.ResponseWriter, r *ht
 	var filters struct {
 		FloorsFrom *int    `json:"floors_from,omitempty"`
 		FloorsTo   *int    `json:"floors_to,omitempty"`
+		Floors     *string `json:"floors,omitempty"`
 		Technology *string `json:"technology,omitempty"`
 	}
 
@@ -138,6 +140,11 @@ func (app *application) getProjectsBenchmarkHandler(w http.ResponseWriter, r *ht
 		filters.FloorsTo = &floorsTo
 	}
 
+	floors := app.readString(r.URL.Query(), "floors", "")
+	if floors != "" {
+		filters.Floors = &floors
+	}
+
 	technology := app.readString(r.URL.Query(), "technology", "")
 	if technology != "" {
 		filters.Technology = &technology
@@ -148,9 +155,21 @@ func (app *application) getProjectsBenchmarkHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	projects, err := app.models.Benchmark.GetProjectsBenchmark(filters)
+	projectFilters := data.GetProjectsBenchmarkFilters{
+		FloorsFrom: filters.FloorsFrom,
+		FloorsTo:   filters.FloorsTo,
+		Floors:     filters.Floors,
+		Technology: filters.Technology,
+	}
+
+	projects, err := app.models.Benchmark.GetProjectsBenchmark(projectFilters)
 	if err != nil {
-		app.serverErrorResponse(w, r, err)
+		switch {
+		case errors.Is(err, data.ErrInvalidFloorFilter):
+			app.badRequestResponse(w, r, err)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
 		return
 	}
 

--- a/internal/data/benchmark.go
+++ b/internal/data/benchmark.go
@@ -167,7 +167,41 @@ func (m BenchmarkModel) GetUnitsBenchmark() ([]*BenchmarkData, error) {
 type GetProjectsBenchmarkFilters struct {
 	FloorsFrom *int    `json:"floors_from,omitempty"`
 	FloorsTo   *int    `json:"floors_to,omitempty"`
+	Floors     *string `json:"floors,omitempty"`
 	Technology *string `json:"technology,omitempty"`
+}
+
+type FloorRange struct {
+	Min           int
+	Max           int
+	IsGreaterThan bool
+}
+
+var validFloorFilters = map[string]FloorRange{
+	"1":    {Min: 1, Max: 1, IsGreaterThan: false},
+	"2":    {Min: 2, Max: 2, IsGreaterThan: false},
+	"3-4":  {Min: 3, Max: 4, IsGreaterThan: false},
+	"5-10": {Min: 5, Max: 10, IsGreaterThan: false},
+	"11+":  {Min: 11, Max: 0, IsGreaterThan: true},
+}
+
+func getValidFloorFilterValues() string {
+	values := make([]string, 0, len(validFloorFilters))
+	for key := range validFloorFilters {
+		values = append(values, key)
+	}
+	return strings.Join(values, ", ")
+}
+
+func parseFloorFilter(value string) (*FloorRange, error) {
+	value = strings.TrimSpace(value)
+
+	floorRange, ok := validFloorFilters[value]
+	if !ok {
+		return nil, fmt.Errorf("%w: '%s' - allowed values are: %s", ErrInvalidFloorFilter, value, getValidFloorFilterValues())
+	}
+
+	return &floorRange, nil
 }
 
 func (m BenchmarkModel) GetProjectsBenchmark(filters GetProjectsBenchmarkFilters) ([]*BenchmarkData, error) {
@@ -188,16 +222,55 @@ func (m BenchmarkModel) GetProjectsBenchmark(filters GetProjectsBenchmarkFilters
 			FROM floors_per_tower fpt
 			WHERE 1=1`
 
-	if filters.FloorsFrom != nil {
-		query += fmt.Sprintf(` AND floor_count >= $%d`, argPosition)
-		args = append(args, *filters.FloorsFrom)
-		argPosition++
-	}
+	if filters.Floors != nil {
+		floorValues := strings.Split(*filters.Floors, ",")
+		var floorConditions []string
 
-	if filters.FloorsTo != nil {
-		query += fmt.Sprintf(` AND floor_count <= $%d`, argPosition)
-		args = append(args, *filters.FloorsTo)
-		argPosition++
+		for _, value := range floorValues {
+			value = strings.TrimSpace(value)
+			if !strings.HasSuffix(value, "+") && len(value) > 0 {
+				if num := strings.TrimSpace(value); num != "" {
+					if _, exists := validFloorFilters[num+"+"]; exists {
+						value = num + "+"
+					}
+				}
+			}
+
+			floorRange, err := parseFloorFilter(value)
+			if err != nil {
+				return nil, err
+			}
+
+			if floorRange.IsGreaterThan {
+				floorConditions = append(floorConditions, fmt.Sprintf("floor_count >= $%d", argPosition))
+				args = append(args, floorRange.Min)
+				argPosition++
+			} else if floorRange.Min == floorRange.Max {
+				floorConditions = append(floorConditions, fmt.Sprintf("floor_count = $%d", argPosition))
+				args = append(args, floorRange.Min)
+				argPosition++
+			} else {
+				floorConditions = append(floorConditions, fmt.Sprintf("(floor_count >= $%d AND floor_count <= $%d)", argPosition, argPosition+1))
+				args = append(args, floorRange.Min, floorRange.Max)
+				argPosition += 2
+			}
+		}
+
+		if len(floorConditions) > 0 {
+			query += " AND (" + strings.Join(floorConditions, " OR ") + ")"
+		}
+	} else {
+		if filters.FloorsFrom != nil {
+			query += fmt.Sprintf(` AND floor_count >= $%d`, argPosition)
+			args = append(args, *filters.FloorsFrom)
+			argPosition++
+		}
+
+		if filters.FloorsTo != nil {
+			query += fmt.Sprintf(` AND floor_count <= $%d`, argPosition)
+			args = append(args, *filters.FloorsTo)
+			argPosition++
+		}
 	}
 
 	query += `),
@@ -219,13 +292,13 @@ func (m BenchmarkModel) GetProjectsBenchmark(filters GetProjectsBenchmarkFilters
 	if filters.Technology != nil {
 		technologies := strings.Split(*filters.Technology, ",")
 		techPlaceholders := make([]string, len(technologies))
-		
+
 		for i, _ := range technologies {
 			techPlaceholders[i] = fmt.Sprintf("$%d", argPosition)
 			args = append(args, strings.TrimSpace(technologies[i]))
 			argPosition++
 		}
-		
+
 		query += fmt.Sprintf(`
 			AND fc.technology = ANY(ARRAY[%s])`, strings.Join(techPlaceholders, ","))
 	}

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -10,10 +10,11 @@ var (
 	ErrEditConflict   = errors.New("edit conflict")
 	ErrNoRowsDeleted  = errors.New("no rows deleted")
 
-	ErrInvalidOptionID = errors.New("option_id does not exist or is invalid")
-	ErrInvalidFloorID  = errors.New("one or more floor_ids are invalid or do not exist")
-	ErrInvalidUnitID   = errors.New("unit_id does not exist or is invalid")
-	ErrUnitIsNotTower  = errors.New("the specified unit is not a tower")
+	ErrInvalidOptionID    = errors.New("option_id does not exist or is invalid")
+	ErrInvalidFloorID     = errors.New("one or more floor_ids are invalid or do not exist")
+	ErrInvalidUnitID      = errors.New("unit_id does not exist or is invalid")
+	ErrUnitIsNotTower     = errors.New("the specified unit is not a tower")
+	ErrInvalidFloorFilter = errors.New("invalid floor filter")
 )
 
 type Models struct {


### PR DESCRIPTION
 ## Novo filtro `floors` para benchmark de projetos

### Endpoint
`GET /v1/benchmark/projects`

### Parâmetro
- `floors` (string, opcional): Filtro de pavimentos com valores múltiplos separados por vírgula

### Valores aceitos
- `1` - Exatamente 1 pavimento
- `2` - Exatamente 2 pavimentos
- `3-4` - De 3 a 4 pavimentos
- `5-10` - De 5 a 10 pavimentos
- `11+` - 11 ou mais pavimentos

### Exemplos de uso
```bash
# Projetos com 1 pavimento
?floors=1

# Projetos com 1 OU 5-10 pavimentos
?floors=1,5-10

# Projetos com 3-4 OU 11+ pavimentos
?floors=3-4,11%2B

# Combinando com technology
?floors=1,2,5-10&technology=structural_masonry,beam_column
```

related issue #117 