### PR TITLE
Adição de modal com aviso sobre uso dos dados antes de finalizar o cadastro

### DIFF
--- a/web/frontend/src/components/layout/dialogs/dialog-warn-signup.tsx
+++ b/web/frontend/src/components/layout/dialogs/dialog-warn-signup.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { TriangleAlert } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface DialogSuccessSignupProps {
+  handleClose: () => void;
+  handleConfirm: () => void;
+}
+export const DialogWarnSignup = ({ handleClose, handleConfirm }: DialogSuccessSignupProps) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog onOpenChange={handleClose} open={true} >
+      <DialogContent>
+        <DialogTitle className='flex items-end gap-4'><TriangleAlert className='fill-amber-300' /> Atenção </DialogTitle>
+        <DialogDescription>
+          <div className="my-8">
+            <p className="text-base text-muted-foreground">
+              Os dados dos projetos de construção são utilizados apenas de forma anonimizada e agregada, sem permitir a identificação individual. Mesmo após a exclusão da conta, esses dados poderão ser mantidos exclusivamente para fins estatísticos e de modelagem, enquanto os dados pessoais do usuário serão eliminados.
+            </p>
+          </div>
+        </DialogDescription>
+
+        <div className='flex justify-end max-md:flex-col-reverse'>
+          <Button onClick={handleClose} className="mt-6 " variant="ghost">
+            <span className="text-sm">Cancelar</span>
+          </Button>
+          <Button onClick={handleConfirm} className="mt-6  md:ml-4" variant="bipc">
+            <span className="text-sm">Confirmar</span>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/web/frontend/src/routes/(public)/sign-up.tsx
+++ b/web/frontend/src/routes/(public)/sign-up.tsx
@@ -19,6 +19,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 
 import { DialogSuccessSignup } from "@/components/layout/dialogs/dialog-success-signup";
+import { DialogWarnSignup } from "@/components/layout/dialogs/dialog-warn-signup";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import Divider from "@/components/ui/divider";
@@ -58,7 +59,7 @@ const SignUp = () => {
   });
   const navigate = useNavigate();
   const { t } = useTranslation();
-
+  const [warnModalIsOpen, setWarnModalIsOpen] = useState(false);
   const { isPending, mutate } = useMutation({
     mutationFn: register,
     onError: (error: AxiosError) => {
@@ -142,7 +143,7 @@ const SignUp = () => {
           <Form {...form}>
             <form
               className="flex flex-col gap-4"
-              onSubmit={form.handleSubmit(handleSubmit)}
+              onSubmit={form.handleSubmit(() => setWarnModalIsOpen(true))}
             >
               <p className="font-bold text-lg">Informações pessoais</p>
               <FormField
@@ -421,6 +422,7 @@ const SignUp = () => {
           </Form>
         </CardContent>
       </Card>
+      {warnModalIsOpen && <DialogWarnSignup handleClose={() => setWarnModalIsOpen(false)} handleConfirm={() => handleSubmit(form.getValues())} />}
       {successModal && <DialogSuccessSignup handleClose={handleClose} />}
     </div>
   );


### PR DESCRIPTION
This pull request introduces a new warning dialog to the signup flow, informing users about how their data will be handled. The dialog appears before finalizing registration, ensuring users are aware of data retention and anonymization practices. The main changes include the creation of the warning dialog component and its integration into the signup process.

**New warning dialog for signup:**

* Added a new `DialogWarnSignup` component that displays a warning about data anonymization and retention, with options to cancel or confirm the signup.
* Integrated the `DialogWarnSignup` dialog into the signup flow by importing and rendering it in the `sign-up.tsx` route. The dialog appears when the user submits the signup form, requiring confirmation before proceeding. [[1]](diffhunk://#diff-f305b75a48eb638d897d60bbef7fd64d691eaf3212156b84ac785de183f4e0faR22) [[2]](diffhunk://#diff-f305b75a48eb638d897d60bbef7fd64d691eaf3212156b84ac785de183f4e0faL61-R62) [[3]](diffhunk://#diff-f305b75a48eb638d897d60bbef7fd64d691eaf3212156b84ac785de183f4e0faL145-R146) [[4]](diffhunk://#diff-f305b75a48eb638d897d60bbef7fd64d691eaf3212156b84ac785de183f4e0faR425)

#132 