### PR TITLE
feat: Contact warning when creating project

### DIFF
--- a/web/frontend/src/components/layout/drawer-form-project.tsx
+++ b/web/frontend/src/components/layout/drawer-form-project.tsx
@@ -248,6 +248,7 @@ export default function DrawerFormProject({
           street: projectData.street || "",
           number: projectData.number || "",
         });
+        setIsAgreementChecked(true);
       } else {
         form.reset({
           name: "",
@@ -580,11 +581,12 @@ export default function DrawerFormProject({
                     id="agreement-checkbox"
                     checked={isAgreementChecked}
                     onChange={(e) => setIsAgreementChecked(e.target.checked)}
+                    disabled={isEditMode}
                     className="mt-1 h-4 w-4 rounded border-yellow-400 text-yellow-600 focus:ring-yellow-500 cursor-pointer flex-shrink-0"
                   />
                   <label
                     htmlFor="agreement-checkbox"
-                    className="text-sm font-medium text-gray-900 dark:text-gray-100 cursor-pointer select-none leading-relaxed"
+                    className="text-sm font-medium text-gray-500 dark:text-gray-100 cursor-pointer select-none leading-relaxed"
                   >
                     Estou ciente da possibilidade de ser contactado para
                     confirmação dos dados do projeto, conforme informado


### PR DESCRIPTION
Related issue: #133 

This pull request enhances the user experience and compliance for project submissions in the `DrawerFormProject` component. The main update introduces a mandatory agreement checkbox, requiring users to acknowledge the possibility of being contacted to confirm project data. Additionally, the codebase receives minor formatting improvements for consistency.

#### User agreement and compliance

* Added a prominent information box explaining the possibility of being contacted up to three years after project completion to confirm submitted data, along with a mandatory checkbox for user acknowledgment. The submit button is now disabled until the checkbox is checked. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R546-R593) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L557-R615)
* Reset the agreement checkbox state whenever the drawer is opened, ensuring users must confirm on each submission.
* Introduced a new state variable `isAgreementChecked` to manage the checkbox state.

#### Code formatting and consistency

* Standardized import statements and improved formatting for JSX elements and component props for better readability and maintainability. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L9-R11) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L33-R33) [[3]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L290-R298) [[4]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L302-R312)

<img width="546" height="599" alt="image" src="https://github.com/user-attachments/assets/f18bcce3-2c0a-4534-8dbc-8312675d5374" />
