### PR TITLE
feat: change state field type from inputText to Select

### DIFF
--- a/web/frontend/src/components/layout/drawer-form-project.tsx
+++ b/web/frontend/src/components/layout/drawer-form-project.tsx
@@ -11,6 +11,7 @@ import useCep from "@/hooks/useLocation";
 import { cn } from "@/lib/utils";
 import { IProject } from "@/types/projects";
 import { masks } from "@/utils/masks";
+import { states } from '@/utils/states';
 import {
   ProjectFormSchema,
   projectFormSchema,
@@ -386,11 +387,25 @@ export default function DrawerFormProject({
                     <FormItem className="flex-1/3">
                       <FormLabel>{t("drawerFormProject.stateLabel")}</FormLabel>
                       <FormControl>
-                        <Input
-                          placeholder={t("drawerFormProject.statePlaceholder")}
-                          disabled={locationLoading}
-                          {...field}
-                        />
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue
+                              placeholder={t(
+                                "drawerFormProject.statePlaceholder"
+                              )}
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {states.map((state) => (
+                              <SelectItem key={state.label} value={state.value.toUpperCase()}>
+                                {state.label} - {state.value}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </FormControl>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
This pull request updates the project drawer form to improve how users select a state when creating or editing a project. The main change is replacing the free-text input for the state field with a dropdown select menu, making state selection more user-friendly and consistent.

**Form usability improvements:**

* Replaced the state field's `Input` component with a `Select` dropdown, allowing users to choose from a predefined list of states instead of typing manually. This reduces errors and ensures consistent data entry.
* Imported the `states` list from `@/utils/states` to populate the dropdown options, ensuring all available states are presented to the user.