### PR TITLE
feat: hide sidebar when navigate on mobile

### DIFF
--- a/web/frontend/src/components/layout/sidebar.tsx
+++ b/web/frontend/src/components/layout/sidebar.tsx
@@ -1,6 +1,8 @@
+import BipcIcon from "@/assets/icons/bipc";
+import CollapseContentIcon from "@/assets/icons/collapse-content";
+import ExpandContentIcon from "@/assets/icons/expand-content";
 import Logo from "@/assets/logo.svg";
 import LogoFull from "@/assets/logo_full.svg";
-import BipcIcon from "@/assets/icons/bipc";
 import { useSummary } from "@/context/summaryContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -20,16 +22,14 @@ import {
   Settings,
   UserPlus,
 } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { BetaWarning } from "../beta-warning";
 import { Notifications } from "../notifications";
 import { Button } from "../ui/button";
 import Divider from "../ui/divider";
 import SidemenuItem from "../ui/sidemenu-item";
-import ExpandContentIcon from "@/assets/icons/expand-content";
-import CollapseContentIcon from "@/assets/icons/collapse-content";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-import { BetaWarning } from "../beta-warning";
 import ModalTraining from "./modal-training";
 
 interface ISidebar {
@@ -62,6 +62,12 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
     setIsMinimized(!isMinimized);
   };
 
+  const closeAll = () => {
+    if (isMobile) {
+      toggleSidebar();
+      hideSummary();
+    }
+  };
   // Versão minimizada do sidebar
   const minimizedSidebar = (
     <div className="h-full flex flex-col py-4 px-3 relative">
@@ -94,7 +100,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
         <BetaWarning minimizedSidebar />
         <ModalTraining
           isAuthenticated={isAuthenticated}
-          onNavigateToSignUp={() => {}}
+          onNavigateToSignUp={() => { }}
           minimizedSidebar
         />
       </div>
@@ -135,6 +141,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
         <Tooltip>
           <TooltipTrigger asChild>
             <Link
+              onClick={closeAll}
               to="/benchmark"
               activeProps={{ className: "bg-zinc-700/30" }}
               className="p-2 hover:bg-zinc-700/30 rounded-md transition-colors flex items-center justify-center"
@@ -150,6 +157,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
         <Tooltip>
           <TooltipTrigger asChild>
             <Link
+              onClick={closeAll}
               to="/privacidade"
               className="p-2 hover:bg-zinc-700/30 rounded-md transition-colors flex items-center justify-center"
             >
@@ -168,6 +176,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link
+                  onClick={closeAll}
                   to="/new_projects"
                   activeProps={{ className: "bg-zinc-700/30" }}
                   className="p-2 hover:bg-zinc-700/30 rounded-md transition-colors flex items-center justify-center"
@@ -183,6 +192,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link
+                  onClick={closeAll}
                   to="/settings"
                   activeProps={{ className: "bg-zinc-700/30" }}
                   className="p-2 hover:bg-zinc-700/30 rounded-md transition-colors flex items-center justify-center"
@@ -211,6 +221,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link
+                  onClick={closeAll}
                   to="/sign-up"
                   activeProps={{ className: "bg-zinc-700/30" }}
                   className="p-2 hover:bg-zinc-700/30 rounded-md transition-colors flex items-center justify-center"
@@ -226,6 +237,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link
+                  onClick={closeAll}
                   to="/login"
                   activeProps={{ className: "bg-zinc-700/30" }}
                   className="p-2 hover:bg-zinc-700/30 rounded-md transition-colors flex items-center justify-center"
@@ -284,7 +296,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
         <BetaWarning />
         <ModalTraining
           isAuthenticated={isAuthenticated}
-          onNavigateToSignUp={() => {}}
+          onNavigateToSignUp={() => { }}
         />
       </div>
 
@@ -298,6 +310,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
           <li>
             <SidemenuItem variant="link">
               <Link
+                onClick={closeAll}
                 to={"/about"}
                 className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
               >
@@ -325,6 +338,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
           <li>
             <SidemenuItem variant="link">
               <Link
+                onClick={closeAll}
                 to="/benchmark"
                 activeProps={activeProps}
                 className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
@@ -337,6 +351,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
           <li>
             <SidemenuItem variant="link">
               <Link
+                onClick={closeAll}
                 to="/privacidade"
                 className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
               >
@@ -355,6 +370,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
               <li>
                 <SidemenuItem variant="link">
                   <Link
+                    onClick={closeAll}
                     to="/new_projects"
                     activeProps={activeProps}
                     className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
@@ -368,6 +384,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
               <li>
                 <SidemenuItem variant="link">
                   <Link
+                    onClick={closeAll}
                     to={"/settings"}
                     activeProps={activeProps}
                     className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
@@ -397,6 +414,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
               <li>
                 <SidemenuItem variant="link">
                   <Link
+                    onClick={closeAll}
                     to="/sign-up"
                     activeProps={activeProps}
                     className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
@@ -411,6 +429,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
               <li>
                 <SidemenuItem variant="link">
                   <Link
+                    onClick={closeAll}
                     to="/login"
                     activeProps={activeProps}
                     className="flex gap-3 items-center w-full p-2 hover:bg-zinc-700/30 rounded-md transition-colors"
@@ -506,8 +525,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
             size={24}
             className="text-white cursor-pointer"
             onClick={() => {
-              toggleSidebar();
-              hideSummary();
+              closeAll();
               localStorage.setItem(
                 "sidebarStatus",
                 sidebarStatus === "open" ? "closed" : "open",
@@ -519,9 +537,7 @@ const Sidebar = ({ handleLogout }: ISidebar) => {
         {/* Overlay */}
         <div
           onClick={() => {
-            toggleSidebar();
-            hideSummary();
-
+            closeAll();
             localStorage.setItem("sidebarStatus", "closed");
           }}
           className={cn(


### PR DESCRIPTION
This pull request refactors the sidebar component in `sidebar.tsx` to improve mobile usability and code organization. The main change is the introduction of a new `closeAll` function, which ensures that both the sidebar and summary are closed when navigation links or overlay are clicked on mobile devices. Additionally, import statements are cleaned up for better readability.

Mobile usability improvements:

* Added a `closeAll` function that closes the sidebar and hides the summary when navigation occurs on mobile devices, and applied it to all relevant navigation links and overlay click handlers. [[1]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R65-R70) [[2]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R144) [[3]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R160) [[4]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R179) [[5]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R195) [[6]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R224) [[7]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R240) [[8]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R313) [[9]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R341) [[10]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R354) [[11]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R373) [[12]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R387) [[13]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R417) [[14]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R432) [[15]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8L509-R528) [[16]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8L522-R540)

Code organization:

* Cleaned up and reordered import statements for icons and components for improved readability and maintainability. [[1]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8R1-L3) [[2]](diffhunk://#diff-1aa9c709e4c4c46b3d0d2c173244e28232e011ac68b756ee85576752f51b31c8L23-L32)