### PR TITLE
fix: Neighborhood and Street fields with bugs - Project Forms

### DIFF
--- a/web/frontend/src/components/layout/drawer-form-project.tsx
+++ b/web/frontend/src/components/layout/drawer-form-project.tsx
@@ -66,6 +66,7 @@ export default function DrawerFormProject({
   const [file, setFile] = useState<File | undefined>(undefined);
   const [isAgreementChecked, setIsAgreementChecked] = useState(false);
   const [filledByCep, setFilledByCep] = useState(false);
+  const [cepFilledFields, setCepFilledFields] = useState<Set<string>>(new Set());
   const [selectedState, setSelectedState] = useState("");
 
   const queryClient = useQueryClient();
@@ -94,7 +95,7 @@ export default function DrawerFormProject({
     searchCep,
   } = useCep();
 
-  const { cities, isLoading: citiesLoading } = useCities(selectedState);
+  const { cities, isLoading: citiesLoading, isError: citiesError } = useCities(selectedState);
 
   const navigate = useNavigate();
 
@@ -243,6 +244,7 @@ export default function DrawerFormProject({
       resetUpdate();
       setIsAgreementChecked(false);
       setFilledByCep(false);
+      setCepFilledFields(new Set());
       setSelectedState("");
 
       if (projectData) {
@@ -279,16 +281,25 @@ export default function DrawerFormProject({
       setFilledByCep(true);
       setSelectedState(locationData.state);
       form.clearErrors("cep");
-      form.setValue("state", locationData.state);
-      form.setValue("city", locationData.city);
-      form.setValue("neighborhood", locationData.neighborhood);
-      form.setValue("street", locationData.street);
+
+      const filled = new Set<string>();
+      if (locationData.state) filled.add("state");
+      if (locationData.city) filled.add("city");
+      if (locationData.neighborhood) filled.add("neighborhood");
+      if (locationData.street) filled.add("street");
+      setCepFilledFields(filled);
+
+      form.setValue("state", locationData.state ?? "");
+      form.setValue("city", locationData.city ?? "");
+      form.setValue("neighborhood", locationData.neighborhood ?? "");
+      form.setValue("street", locationData.street ?? "");
     }
   }, [locationData, form]);
 
   useEffect(() => {
     if (isError) {
       setFilledByCep(false);
+      setCepFilledFields(new Set());
       setSelectedState("");
       toast.error(t("error.errorFetchZipCode"), {
         description: t("warn.verifyZipCode"),
@@ -382,6 +393,7 @@ export default function DrawerFormProject({
                             field.onChange(e.target.value);
                             if (raw.length === 0 && filledByCep) {
                               setFilledByCep(false);
+                              setCepFilledFields(new Set());
                               setSelectedState("");
                               form.setValue("state", "");
                               form.setValue("city", "");
@@ -463,6 +475,7 @@ export default function DrawerFormProject({
                             onChange={field.onChange}
                             disabled={!selectedState || locationLoading}
                             isLoading={citiesLoading}
+                            isError={citiesError}
                             placeholder={
                               !selectedState
                                 ? t("drawerFormProject.selectStateFirst")
@@ -489,7 +502,7 @@ export default function DrawerFormProject({
                         placeholder={t(
                           "drawerFormProject.neighborhoodPlaceholder",
                         )}
-                        disabled={filledByCep || locationLoading}
+                        disabled={cepFilledFields.has("neighborhood") || locationLoading}
                         {...field}
                       />
                     </FormControl>
@@ -509,7 +522,7 @@ export default function DrawerFormProject({
                       <FormControl>
                         <Input
                           placeholder={t("drawerFormProject.streetPlaceholder")}
-                          disabled={filledByCep || locationLoading}
+                          disabled={cepFilledFields.has("street") || locationLoading}
                           {...field}
                         />
                       </FormControl>

--- a/web/frontend/src/components/ui/city-combobox.tsx
+++ b/web/frontend/src/components/ui/city-combobox.tsx
@@ -16,6 +16,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
 import { type CityOption } from "@/hooks/useCities";
 import { useTranslation } from "react-i18next";
 
@@ -25,6 +26,7 @@ interface CityComboboxProps {
   onChange: (value: string) => void;
   disabled?: boolean;
   isLoading?: boolean;
+  isError?: boolean;
   placeholder?: string;
   searchPlaceholder?: string;
   emptyMessage?: string;
@@ -36,6 +38,7 @@ export function CityCombobox({
   onChange,
   disabled = false,
   isLoading = false,
+  isError = false,
   placeholder,
   searchPlaceholder,
   emptyMessage,
@@ -48,6 +51,18 @@ export function CityCombobox({
   const displaySearchPlaceholder =
     searchPlaceholder ?? t("drawerFormProject.citySearchPlaceholder");
   const displayEmpty = emptyMessage ?? t("drawerFormProject.cityNotFound");
+
+  // Fallback to manual input when the cities API fails or returns empty (after loading)
+  if (isError || (!isLoading && cities.length === 0 && !disabled)) {
+    return (
+      <Input
+        placeholder={displayPlaceholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+      />
+    );
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen} modal>

--- a/web/frontend/src/hooks/useCities.ts
+++ b/web/frontend/src/hooks/useCities.ts
@@ -12,7 +12,7 @@ export interface CityOption {
 }
 
 const useCities = (uf: string) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ["ibge-cities", uf],
     queryFn: async () => {
       const res = await externalApi.get<IBGECity[]>(
@@ -31,6 +31,7 @@ const useCities = (uf: string) => {
   return {
     cities: data ?? [],
     isLoading,
+    isError,
   };
 };
 


### PR DESCRIPTION
This pull request enhances the address form experience by improving how fields are filled and disabled based on CEP (postal code) lookups and by providing a fallback for city selection when the external API fails. The changes also add better error handling and state management for city and address fields.

**Improvements to address form behavior:**

* Introduced a new state variable `cepFilledFields` in `drawer-form-project.tsx` to track which address fields were auto-filled by CEP lookup, allowing for more granular disabling of individual fields rather than all-or-nothing. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R69) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L282-R302) [[3]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R247) [[4]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R396)
* Updated the disabling logic for the `neighborhood` and `street` fields to depend on `cepFilledFields`, so only fields actually filled by CEP are disabled, improving user flexibility. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L492-R505) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L512-R525)

**City selection improvements and error handling:**

* Extended the `useCities` hook and `CityCombobox` component to propagate and handle errors (`isError`), and to provide a manual input fallback if the cities API fails or returns no results, ensuring the user can always enter a city. [[1]](diffhunk://#diff-51213ab46580d9af4b3eb3b0d7ff0546a9cb3f5319ab14bbd11e5a537ad976b3L15-R15) [[2]](diffhunk://#diff-51213ab46580d9af4b3eb3b0d7ff0546a9cb3f5319ab14bbd11e5a537ad976b3R34) [[3]](diffhunk://#diff-c205ac435597b3f61ff1cd21560f62652426b0eea5b0e7896a21ecdd589a664aR29) [[4]](diffhunk://#diff-c205ac435597b3f61ff1cd21560f62652426b0eea5b0e7896a21ecdd589a664aR41) [[5]](diffhunk://#diff-c205ac435597b3f61ff1cd21560f62652426b0eea5b0e7896a21ecdd589a664aR55-R66)
* Passed the new `isError` prop from the form to the `CityCombobox` and updated the UI to reflect loading and error states for city selection. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L97-R98) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R478)

**Component and state reset improvements:**

* Reset `cepFilledFields` and related state variables when the form is cleared or when a CEP lookup fails, ensuring the UI remains consistent and avoids stale state. [[1]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R247) [[2]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8L282-R302) [[3]](diffhunk://#diff-4669870c3e7cbd222945e0a0c8f458f435bfe175b9e236374058096a334091f8R396)