### PR TITLE
dados do projeto

### DIFF
--- a/cmd/api/report.go
+++ b/cmd/api/report.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -30,26 +32,26 @@ import (
 )
 
 func (app *application) reportHandler(w http.ResponseWriter, r *http.Request) {
-	// projectID, err := app.readUUIDParam(r, "projectID")
-	// if err != nil {
-	// 	app.badRequestResponse(w, r, err)
-	// 	return
-	// }
+	projectID, err := app.readUUIDParam(r, "projectID")
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
 
-	// project, err := app.models.Projects.GetByID(projectID)
-	// if err != nil {
-	// 	switch {
-	// 	case errors.Is(err, data.ErrRecordNotFound):
-	// 		app.notFoundResponse(w, r)
-	// 	default:
-	// 		app.serverErrorResponse(w, r, err)
-	// 	}
-	// 	return
-	// }
+	project, err := app.models.Projects.GetByID(projectID)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			app.notFoundResponse(w, r)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
-	err := r.ParseMultipartForm(256 << 10)
+	err = r.ParseMultipartForm(256 << 10)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
@@ -81,7 +83,7 @@ func (app *application) reportHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m, err := GetMaroto(co2Bytes, energyBytes)
+	m, err := GetMaroto(project, co2Bytes, energyBytes)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -98,7 +100,7 @@ func (app *application) reportHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(document.GetBytes())
 }
 
-func GetMaroto(co2Bytes, energyBytes []byte) (core.Maroto, error) {
+func GetMaroto(project *data.ProjectWithUnits, co2Bytes, energyBytes []byte) (core.Maroto, error) {
 	customFonts := []*entity.CustomFont{
 		{Family: "Inter", Style: fontstyle.Normal, Bytes: assets.InterRegular},
 		{Family: "Inter", Style: fontstyle.Bold, Bytes: assets.InterBold},
@@ -115,7 +117,7 @@ func GetMaroto(co2Bytes, energyBytes []byte) (core.Maroto, error) {
 	}
 
 	cfg := marotocfg.NewBuilder().
-		WithDebug(true).
+		//WithDebug(true).
 		WithCustomFonts(customFonts).
 		WithDefaultFont(&props.Font{Family: "Inter", Style: fontstyle.Normal, Size: 12, Color: getBlackColor()}).
 		WithPageNumber(pageNumber).
@@ -150,9 +152,9 @@ func GetMaroto(co2Bytes, energyBytes []byte) (core.Maroto, error) {
 	)
 
 	m.AddAutoRow(
-		text.NewCol(7, "08.1234.567.890-12", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(7, safe(project.Siop), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(7, "0123.4567.8901-23", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(7, safe(project.Apf), getValueStyle()).WithStyle(getBorderStyle()),
 	)
 
 	m.AddRow(2)
@@ -174,19 +176,19 @@ func GetMaroto(co2Bytes, energyBytes []byte) (core.Maroto, error) {
 	)
 
 	m.AddAutoRow(
-		text.NewCol(10, truncate("Residencial modelo", 36), getValueStyle()).WithStyle(getBorderStyle()),
-		col.New(1),
-		text.NewCol(4, "Torre", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(10, truncate(project.Name, 36), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
 		text.NewCol(4, "", getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(7, data.PhaseMap["released_for_construction"], getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(4, "", getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(5, "36", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(7, data.PhaseMap[project.Phase], getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(4, "4", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(5, "", getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(5, "561,1", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(4, "", getValueStyle()).WithStyle(getBorderStyle()),
+		col.New(1),
+		text.NewCol(5, "", getValueStyle()).WithStyle(getBorderStyle()),
 	)
 
 	m.AddRow(2)
@@ -196,7 +198,7 @@ func GetMaroto(co2Bytes, energyBytes []byte) (core.Maroto, error) {
 	)
 
 	m.AddAutoRow(
-		text.NewCol(5, "2244,4", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(5, fmt.Sprintf("%.2f", project.Area), getValueStyle()).WithStyle(getBorderStyle()),
 	)
 
 	m.AddRow(2)
@@ -216,17 +218,17 @@ func GetMaroto(co2Bytes, energyBytes []byte) (core.Maroto, error) {
 	)
 
 	m.AddAutoRow(
-		text.NewCol(12, truncate("Avenida Álvaro Maia", 45), getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(12, truncate(safe(project.Street), 45), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(4, "69025-310", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(4, safe(project.CEP), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(2, "486", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(2, safe(project.Number), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(12, truncate("Centro", 45), getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(12, truncate(safe(project.Neighborhood), 45), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(11, truncate("Manaus", 39), getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(11, truncate(project.City, 39), getValueStyle()).WithStyle(getBorderStyle()),
 		col.New(1),
-		text.NewCol(2, "AM", getValueStyle()).WithStyle(getBorderStyle()),
+		text.NewCol(2, project.State, getValueStyle()).WithStyle(getBorderStyle()),
 	)
 
 	m.AddRow(5)
@@ -1113,4 +1115,11 @@ func truncate(s string, maxRunes int) string {
 		return s
 	}
 	return string(r[:maxRunes-3]) + "..."
+}
+
+func safe(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }


### PR DESCRIPTION
This pull request refactors the `reportHandler` and `GetMaroto` functions in `cmd/api/report.go` to use actual project data instead of hardcoded values when generating reports. It also improves error handling and code safety for accessing project fields.

**Project Data Integration:**
- The handler now fetches the `projectID` from the request, retrieves the corresponding project from the database, and passes the project data to `GetMaroto`, replacing previous hardcoded values in the report with actual project attributes [[1]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L33-R54) [[2]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L84-R86) [[3]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L101-R103).
- Report fields such as SIOP, APF, project name, phase, area, address, and others now use values from the `project` object, with appropriate handling for potentially missing data [[1]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L153-R157) [[2]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L177-R191) [[3]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L199-R201) [[4]](diffhunk://#diff-66e67bec41b0bc23bffda002f11e7e0397e6733511959dbcacc32bd127811670L219-R231).

**Error Handling and Safety:**
- Added a `safe` helper function to gracefully handle nil pointer dereferences for optional project fields.
- Improved error variable reuse and ensured all errors are handled appropriately in the handler.

**Code Quality Improvements:**
- Commented out the debug mode in the Maroto configuration for cleaner output.
- Added missing imports for `errors` and `fmt` required by the new logic.