### PR TITLE
feat: Add benchmark plot translations 

### DIFF
--- a/web/frontend/src/components/charts/d3chart.tsx
+++ b/web/frontend/src/components/charts/d3chart.tsx
@@ -762,7 +762,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       ctx.fillStyle = "#64748b";
       ctx.textAlign = "left";
       ctx.textBaseline = "bottom";
-      ctx.fillText("linha de base", 4, baselineY - 3);
+      ctx.fillText(t.benchmark.chartTypes.cumulativeFraction.baseLine, 4, baselineY - 3);
       ctx.restore();
     }
 
@@ -781,7 +781,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       ctx.fillStyle = "#00A650";
       ctx.textAlign = "left";
       ctx.textBaseline = "top";
-      ctx.fillText("PPp 5%", p5LineX + 4, 4);
+      ctx.fillText(t.benchmark.chartTypes.cumulativeFraction.ppp5Line, p5LineX + 4, 4);
       ctx.restore();
     }
 

--- a/web/frontend/src/i18n/translations/en.ts
+++ b/web/frontend/src/i18n/translations/en.ts
@@ -657,6 +657,8 @@ export const en: Translations = {
         yAxisLabel: "Potential Mitigation",
         xAxisLabelCarbon: "Embodied Carbon",
         xAxisLabelEnergy: "Energy Consumption",
+        baseLine: "baseline",
+        ppp5Line: "PPp 5%"
       },
       classification: {
         name: "Classification",

--- a/web/frontend/src/i18n/translations/pt-BR.ts
+++ b/web/frontend/src/i18n/translations/pt-BR.ts
@@ -658,6 +658,8 @@ export const ptBR = {
         yAxisLabel: "Potencial de mitigação",
         xAxisLabelCarbon: "Carbono Embutido",
         xAxisLabelEnergy: "Energia Embutida",
+        baseLine: "linha de base",
+        ppp5Line: "PPp 5%"
       },
       classification: {
         name: "Classificação",


### PR DESCRIPTION
This pull request improves the internationalization (i18n) of chart label text in the D3 gradient range chart component, ensuring that labels are translated based on the selected language instead of being hardcoded.

**Internationalization improvements:**

* Replaced hardcoded chart labels in `D3GradientRangeChart` with values from the translation object, making the labels dynamic and translatable. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL765-R765) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL784-R784)

**Translation files updates:**

* Added `baseLine` and `ppp5Line` keys to the English (`en.ts`) and Brazilian Portuguese (`pt-BR.ts`) translation files to support the new dynamic chart labels. [[1]](diffhunk://#diff-87f1463661ff74ec36b37475d3759e30beea831277c5d62efc96ffa2c462d08dR660-R661) [[2]](diffhunk://#diff-cc3dd692fe604a06e5a222121106800d15e3a8c42e0b73720316649fe5d0d016R661-R662)