### PR TITLE
fix: Steel Material behaviour

### DIFF
--- a/web/frontend/src/components/layout/drawer-form-module/steel-material-list.tsx
+++ b/web/frontend/src/components/layout/drawer-form-module/steel-material-list.tsx
@@ -36,8 +36,7 @@ interface SteelMaterialItemProps {
   fieldId: string;
   materialOptions: Array<{ value: string; label: string }>;
   resistanceOptions: Array<{ value: string; label: string }>;
-  usedMaterials: string[];
-  usedResistances: string[];
+  otherCombinations: string[]; // "material:resistance" pairs from OTHER rows
   onRemove: () => void;
   canRemove: boolean;
 }
@@ -50,8 +49,7 @@ const SteelMaterialItem = ({
   fieldId,
   materialOptions,
   resistanceOptions,
-  usedMaterials,
-  usedResistances,
+  otherCombinations,
   onRemove,
   canRemove,
 }: SteelMaterialItemProps) => {
@@ -78,6 +76,13 @@ const SteelMaterialItem = ({
   const filteredResistanceOptions = resistanceOptions.filter((opt) =>
     allowedResistances.includes(opt.value),
   );
+
+  // Uma combinação está desabilitada se já existe em outra linha,
+  // exceto quando material === "other" E resistance === "other"
+  const isCombinationUsed = (mat: string, res: string) => {
+    if (mat === "other" && res === "other") return false;
+    return otherCombinations.includes(`${mat}:${res}`);
+  };
 
   // Resetar resistência quando o material muda e o valor atual não é mais válido
   useEffect(() => {
@@ -109,18 +114,30 @@ const SteelMaterialItem = ({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {materialOptions.map((opt) => (
-                        <SelectItem
-                          key={opt.value}
-                          value={opt.value}
-                          disabled={
-                            usedMaterials.includes(opt.value) &&
-                            currentMaterial !== opt.value
-                          }
-                        >
-                          {opt.label}
-                        </SelectItem>
-                      ))}
+                      {materialOptions.map((opt) => {
+                        // A material option is disabled if ALL its allowed resistances
+                        // are already used in other rows (and it's not "other"+"other")
+                        const matResistances =
+                          allowedResistancesByMaterial[opt.value] ??
+                          resistanceOptions.map((r) => r.value);
+                        const allCombinationsUsed =
+                          opt.value !== "other" &&
+                          matResistances.every((res) =>
+                            isCombinationUsed(opt.value, res),
+                          );
+                        return (
+                          <SelectItem
+                            key={opt.value}
+                            value={opt.value}
+                            disabled={
+                              allCombinationsUsed &&
+                              currentMaterial !== opt.value
+                            }
+                          >
+                            {opt.label}
+                          </SelectItem>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
                 </FormControl>
@@ -148,7 +165,7 @@ const SteelMaterialItem = ({
                           key={opt.value}
                           value={opt.value}
                           disabled={
-                            usedResistances.includes(opt.value) &&
+                            isCombinationUsed(currentMaterial, opt.value) &&
                             currentResistance !== opt.value
                           }
                         >
@@ -272,15 +289,6 @@ const SteelMaterialList = ({
     return sum + (isNaN(numericValue) ? 0 : numericValue);
   }, 0);
 
-  // Coletar materiais e resistências já utilizados
-  const usedMaterials = (steelArray || [])
-    .map((item: any) => item?.material)
-    .filter(Boolean);
-
-  const usedResistances = (steelArray || [])
-    .map((item: any) => item?.resistance)
-    .filter(Boolean);
-
   const materialOptions = allowedMaterials.map((key) => ({
     value: key,
     label: {
@@ -316,31 +324,70 @@ const SteelMaterialList = ({
         </div>
       </div>
 
-      {fields.map((field, index) => (
-        <SteelMaterialItem
-          key={field.id}
-          form={form}
-          name={name}
-          index={index}
-          fieldId={field.id}
-          materialOptions={materialOptions}
-          resistanceOptions={resistanceOptions}
-          usedMaterials={usedMaterials}
-          usedResistances={usedResistances}
-          onRemove={() => remove(index)}
-          canRemove={fields.length > 1}
-        />
-      ))}
+      {fields.map((field, index) => {
+        // combinations from all OTHER rows (by index)
+        const otherCombinations = (steelArray || [])
+          .map((item: any, i: number) => {
+            if (i === index || !item?.material || !item?.resistance) return null;
+            return `${item.material}:${item.resistance}`;
+          })
+          .filter(Boolean) as string[];
+        return (
+          <SteelMaterialItem
+            key={field.id}
+            form={form}
+            name={name}
+            index={index}
+            fieldId={field.id}
+            materialOptions={materialOptions}
+            resistanceOptions={resistanceOptions}
+            otherCombinations={otherCombinations}
+            onRemove={() => remove(index)}
+            canRemove={fields.length > 1}
+          />
+        );
+      })}
 
       <Button
         type="button"
         variant="outline"
         size="sm"
         onClick={() => {
-          const defaultMaterial = allowedMaterials[0] ?? "rebar";
+          const allowedResistancesByMaterial: Record<string, string[]> = {
+            rebar: ["CA50", "CA60", "other"],
+            mesh: ["CA60", "other"],
+            strand: ["CP190", "other"],
+            other: ["CA50", "CA60", "CP190", "other"],
+          };
+
+          const currentCombinations = (steelArray || [])
+            .filter((item: any) => item?.material && item?.resistance)
+            .map((item: any) => `${item.material}:${item.resistance}`);
+
+          // Encontrar a primeira combinação material+resistance não utilizada
+          let foundMaterial = allowedMaterials[0] ?? "rebar";
+          let foundResistance = defaultResistanceByMaterial[foundMaterial] ?? "CA50";
+
+          outer: for (const mat of allowedMaterials) {
+            const resistances = allowedResistancesByMaterial[mat] ?? ["CA50"];
+            for (const res of resistances) {
+              // other+other sempre é permitido
+              if (mat === "other" && res === "other") {
+                foundMaterial = mat;
+                foundResistance = res;
+                break outer;
+              }
+              if (!currentCombinations.includes(`${mat}:${res}`)) {
+                foundMaterial = mat;
+                foundResistance = res;
+                break outer;
+              }
+            }
+          }
+
           append({
-            material: defaultMaterial,
-            resistance: defaultResistanceByMaterial[defaultMaterial] ?? "CA50",
+            material: foundMaterial,
+            resistance: foundResistance,
             mass: "0",
           });
         }}

--- a/web/frontend/src/i18n/translations/en.ts
+++ b/web/frontend/src/i18n/translations/en.ts
@@ -731,11 +731,11 @@ export const en: Translations = {
     learnMore: "Learn more...",
   },
   phase: {
-    preliminary_study: "Schematic Design (SD)",
+    preliminary_study: "Schematic Design",
     not_defined: "Not Defined",
-    basic_project: "Design Development (DD)",
-    executive_project: "Construction Documents (CD)",
-    released_for_construction: "Issued for Construction (IFC)",
+    basic_project: "Design Development",
+    executive_project: "Construction Documents",
+    released_for_construction: "Issued for Construction",
   },
   card: {
     created: "Created",


### PR DESCRIPTION
Related issue: 
- https://github.com/Benchmark-CO2/bipc/issues/303

This pull request refactors how duplicate material and resistance combinations are handled in the steel material list form. Instead of tracking used materials and resistances separately, the code now considers the unique pairs of material and resistance already selected in other rows, preventing users from selecting the same combination more than once (except for "other:other", which is always allowed). It also improves how new rows are added, ensuring only unused combinations are pre-selected. Additionally, there are minor updates to English translation strings.

**Steel material combination validation improvements:**

* Replaces `usedMaterials` and `usedResistances` with `otherCombinations`, which tracks all "material:resistance" pairs used in other rows, and introduces logic to disable options that would duplicate existing combinations, except for "other:other". (`steel-material-list.tsx`) [[1]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L39-R39) [[2]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L53-R52) [[3]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2R80-R86) [[4]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L112-R140) [[5]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L151-R168) [[6]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L275-L283) [[7]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L319-R335) [[8]](diffhunk://#diff-b72192cf2acde7ae82dd66524c3f17096c9f43ef9153fe44ca40a11add0dd0d2L328-R390)

* When adding a new steel material row, the code now automatically selects the first available combination of material and resistance that hasn't been used yet (with "other:other" always allowed), improving the user experience. (`steel-material-list.tsx`)

**Translation updates:**

* Simplifies English translation strings for project phases, removing abbreviations. (`translations/en.ts`)