### PR TITLE
feat: add improvements to summary charts

### DIFF
--- a/web/frontend/src/components/charts/d3chart.tsx
+++ b/web/frontend/src/components/charts/d3chart.tsx
@@ -122,7 +122,7 @@ const useChartDimensions = (
   return useMemo(() => {
     const margin = {
       top: isExpanded ? 15 : 20,
-      right: isMobile ? 0 : showProcelScale ? 112 : 20,
+      right: isMobile ? 0 : showProcelScale ? 40 : 20,
       bottom: isMobile ? 20 : 35,
       left: isMobile ? 45 : 80,
     };
@@ -133,11 +133,8 @@ const useChartDimensions = (
         return Math.max(0, props.width - margin.left - margin.right);
       }
       if (containerWidth > 0) return containerWidth - margin.left - margin.right;
-      // Fallback when container not yet measured
-      const screenWidth = window.innerWidth;
-      if (isMobile) return screenWidth * 0.6;
-      if (isExpanded) return screenWidth * 0.8;
-      return screenWidth * 0.4;
+      // Return 0 when container not yet measured - will skip drawing
+      return 0;
     };
 
     const height = () => {
@@ -252,9 +249,29 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
   // Measure container immediately before first paint so PROCEL scale renders correctly
   useLayoutEffect(() => {
     if (containerRef.current) {
-      setContainerWidth(containerRef.current.getBoundingClientRect().width);
+      const width = containerRef.current.getBoundingClientRect().width;
+      if (width > 0) {
+        setContainerWidth(width);
+      }
     }
   }, []);
+
+  // Force redraw after initial mount when container is measured
+  useEffect(() => {
+    if (containerRef.current && containerWidth === 0) {
+      // Retry measurement after a short delay if initial measurement failed
+      const timer = setTimeout(() => {
+        if (containerRef.current) {
+          const width = containerRef.current.getBoundingClientRect().width;
+          if (width > 0) {
+            setContainerWidth(width);
+          }
+        }
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [containerWidth]);
+
   const selectedBarIds = useMemo(
     () => new Set((selectedBars || []).map((id) => String(id))),
     [selectedBars],
@@ -297,7 +314,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
   const hasMoreValue =
     totalProjects > 0
       ? parseFloat((maxData[maxData.length - 1] || 0).toFixed(2)) >
-        maxMaxDataValue
+      maxMaxDataValue
       : false;
 
   const {
@@ -418,17 +435,17 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
             max: d.max,
             label:
               selectedMinBarIds.has(String(d.minId ?? d.id)) ||
-              selectedMaxBarIds.has(String(d.maxId ?? d.id))
+                selectedMaxBarIds.has(String(d.maxId ?? d.id))
                 ? d.label
                 : undefined,
             floors:
               selectedMinBarIds.has(String(d.minId ?? d.id)) ||
-              selectedMaxBarIds.has(String(d.maxId ?? d.id))
+                selectedMaxBarIds.has(String(d.maxId ?? d.id))
                 ? d.floors
                 : undefined,
             technology:
               selectedMinBarIds.has(String(d.minId ?? d.id)) ||
-              selectedMaxBarIds.has(String(d.maxId ?? d.id))
+                selectedMaxBarIds.has(String(d.maxId ?? d.id))
                 ? d.technology
                 : undefined,
           },
@@ -463,6 +480,8 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
   // Canvas drawing function
   const drawChart = useCallback(() => {
     if (!canvasRef.current) return;
+    // Skip drawing if dimensions are not yet valid
+    if (_width <= 0 || _height <= 0) return;
 
     const canvas = canvasRef.current;
     const ctx = canvas.getContext("2d", { alpha: false });
@@ -526,7 +545,8 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       .scaleLinear()
       .domain(yScale.domain())
       .range(yScale.range().map((r) => r * transform.k + transform.y));
-    const zoomRadiusFactor = Math.max(1, transform.k);
+    // Keep circles at constant visual size regardless of zoom level
+    const zoomRadiusFactor = 1;
 
     // Draw grid lines
     ctx.strokeStyle = DEFAULT_COLORS.GRID;
@@ -573,6 +593,19 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       const lineX = newXScale(p5Value);
       p5LineX = lineX;
       p5LineInView = lineX >= 0 && lineX <= _width;
+    }
+
+    // Pre-compute mid curve regression for bar split point
+    let midPredict: ((yVal: number) => number) | null = null;
+    if (showMidCurve && data.length >= 3) {
+      const sorted = [...data].sort((a, b) => a.y - b.y);
+      const raw: [number, number][] = sorted.map((d) => [(d.min + d.max) / 2, d.y]);
+      const regression = regressionPoly()
+        .x((d: [number, number]) => d[1])
+        .y((d: [number, number]) => d[0])
+        .order(Math.min(4, raw.length - 1));
+      const result = regression(raw);
+      midPredict = (yVal: number) => Math.max(0, result.predict(yVal));
     }
 
     // First pass: Draw circles for non-selected items
@@ -655,18 +688,34 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
         const barWidth = Math.max(1, x2 - x1);
 
         // Bar connecting min and max only when both endpoints are selected
+        // Split bar: blue from min to mid, orange from mid to max
         if (!hideBars && isPairSelected) {
-          const barGradient = ctx.createLinearGradient(x1, y, x2, y);
-          barGradient.addColorStop(0, DEFAULT_COLORS.GRADIENT_RANGE[1]);
-          barGradient.addColorStop(1, DEFAULT_COLORS.GRADIENT_RANGE[3]);
-          ctx.fillStyle = barGradient;
+          // Use midPredict regression if available, otherwise use simple average
+          const midValue = midPredict ? midPredict(d.y) : (d.min + d.max) / 2;
+          const xMid = newXScale(midValue);
+          const rr = isExpanded ? barHeight / 2 : 2;
+
+          // Blue half: min → mid
+          ctx.fillStyle = DEFAULT_COLORS.START;
           ctx.beginPath();
           (ctx as any).roundRect(
             x1,
             barY,
-            barWidth,
+            Math.max(1, xMid - x1),
             barHeight,
-            isExpanded ? barHeight / 2 : 2,
+            { upperLeft: rr, lowerLeft: rr, upperRight: 0, lowerRight: 0 },
+          );
+          ctx.fill();
+
+          // Orange half: mid → max
+          ctx.fillStyle = DEFAULT_COLORS.END;
+          ctx.beginPath();
+          (ctx as any).roundRect(
+            xMid,
+            barY,
+            Math.max(1, x2 - xMid),
+            barHeight,
+            { upperLeft: 0, lowerLeft: 0, upperRight: rr, lowerRight: rr },
           );
           ctx.fill();
         }
@@ -703,21 +752,21 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
           ctx.stroke();
         }
 
-        // Arrow between PPp 5% line and x2 (max) for projects worse than top 5%
+        // Arrow between PPp 5% line and x1 (min/C) for projects worse than top 5%
         if (
           !hideBars &&
           isPairSelected &&
           p5LineX !== null &&
-          x2 > p5LineX + radius * 2
+          x1 > p5LineX + radius * 2
         ) {
           const arrowY = y;
           const arrowLeft = p5LineX + 2;
-          const arrowRight = x2 - radius;
+          const arrowRight = x1 - radius;
           const headSize = isExpanded ? 6 : 4;
 
           ctx.save();
-          ctx.strokeStyle = "#00A650";
-          ctx.fillStyle = "#00A650";
+          ctx.strokeStyle = "#7B2D8E";
+          ctx.fillStyle = "#7B2D8E";
           ctx.lineWidth = 1.5;
 
           // Horizontal line
@@ -752,12 +801,10 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       ctx.save();
       ctx.strokeStyle = "#64748b";
       ctx.lineWidth = 1.5;
-      ctx.setLineDash([6, 4]);
       ctx.beginPath();
       ctx.moveTo(0, baselineY);
       ctx.lineTo(_width, baselineY);
       ctx.stroke();
-      ctx.setLineDash([]);
       ctx.font = "11px sans-serif";
       ctx.fillStyle = "#64748b";
       ctx.textAlign = "left";
@@ -766,7 +813,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       ctx.restore();
     }
 
-    // Draw PPp 5% line on top of all points
+    // Draw 5% line on top of all points
     if (p5LineX !== null && p5LineInView) {
       ctx.save();
       ctx.strokeStyle = "#00A650";
@@ -781,7 +828,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       ctx.fillStyle = "#00A650";
       ctx.textAlign = "left";
       ctx.textBaseline = "top";
-      ctx.fillText(t.benchmark.chartTypes.cumulativeFraction.ppp5Line, p5LineX + 4, 4);
+      ctx.fillText("5%", p5LineX + 4, 4);
       ctx.restore();
     }
 
@@ -916,7 +963,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       ctx.save();
       // Clip to chart height so bands don't overflow vertically
       ctx.beginPath();
-      ctx.rect(barX, 0, barWidth + PROCEL_SCALE_CONFIG.TICK_SIZE + 30, _height);
+      ctx.rect(barX, 0, barWidth + 5, _height);
       ctx.clip();
 
       // Each class covers 25% of the domain [0,1]:
@@ -1028,8 +1075,10 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
   useEffect(() => {
     if (!canvasRef.current) return;
 
-    // Initial draw
-    drawChart();
+    // Initial draw with a small delay to ensure container is measured
+    const initialDrawTimer = setTimeout(() => {
+      drawChart();
+    }, 10);
 
     const canvas = canvasRef.current;
 
@@ -1093,6 +1142,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
 
     // Cleanup
     return () => {
+      clearTimeout(initialDrawTimer);
       canvas.removeEventListener("dblclick", handleDoubleClick);
       canvas.removeEventListener("mousemove", handleCanvasMouseMove as any);
       canvas.removeEventListener("mouseleave", handleCanvasMouseLeave);
@@ -1135,6 +1185,16 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
     }
     animationFrameRef.current = requestAnimationFrame(drawChart);
   }, [selectedBars, selectedMinBars, selectedMaxBars, drawChart]);
+
+  // Redraw when container dimensions or showProcelScale changes
+  useEffect(() => {
+    if (containerWidth > 0) {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+      animationFrameRef.current = requestAnimationFrame(drawChart);
+    }
+  }, [containerWidth, showProcelScale, drawChart]);
 
   const labelX =
     UNIT_LABELS[unit as keyof typeof UNIT_LABELS] || t.benchmark.chartTypes.cumulativeFraction.xAxisLabelCarbon;

--- a/web/frontend/src/components/charts/exportChart.ts
+++ b/web/frontend/src/components/charts/exportChart.ts
@@ -280,13 +280,23 @@ export async function exportChartToPng(
     if (by >= 0 && by <= chartH) baselineY = by;
   }
 
-  // PPp 5% line
+  // PPp 5% line and 5% reference values for V calculation
   let p5LineX: number | null = null;
   let p5LineInView = false;
+  let c5Value: number | null = null; // C5% - min value at 5th percentile
+  let r5Value: number | null = null; // R5% - max value at 5th percentile
   if (showTop5Line && data.length > 0) {
-    const sorted = [...data].map((d) => d[top5Field]).sort((a, b) => a - b);
-    const idx = Math.floor(sorted.length * top5Percentile);
-    const p5Value = sorted[Math.min(idx, sorted.length - 1)];
+    // Calculate C5% (5th percentile of min values)
+    const sortedMin = [...data].map((d) => d.min).sort((a, b) => a - b);
+    const idx = Math.floor(sortedMin.length * top5Percentile);
+    c5Value = sortedMin[Math.min(idx, sortedMin.length - 1)];
+    
+    // Calculate R5% (5th percentile of max values)
+    const sortedMax = [...data].map((d) => d.max).sort((a, b) => a - b);
+    r5Value = sortedMax[Math.min(idx, sortedMax.length - 1)];
+    
+    // Use the specified field for the PPp line (default: min)
+    const p5Value = top5Field === "min" ? c5Value : r5Value;
     p5LineX = xScale(p5Value);
     p5LineInView = p5LineX >= 0 && p5LineX <= chartW;
   }
@@ -295,7 +305,10 @@ export async function exportChartToPng(
   let midPredict: ((yVal: number) => number) | null = null;
   if (showMidCurve && data.length >= 3) {
     const sorted = [...data].sort((a, b) => a.y - b.y);
-    const raw: [number, number][] = sorted.map((d) => [(d.min + d.max) / 2, d.y]);
+    const raw: [number, number][] = sorted.map((d) => [
+      (d.min + d.max) / 2,
+      d.y,
+    ]);
     const regression = regressionPoly()
       .x((d: [number, number]) => d[1])
       .y((d: [number, number]) => d[0])
@@ -347,7 +360,13 @@ export async function exportChartToPng(
   });
 
   // ── Pass 2: selected points (on top) ────────────────────────────────────
-  let selectedAnnotation: { x1: number; x2: number; xMid: number; y: number; barHeight: number } | null = null;
+  let selectedAnnotation: {
+    x1: number;
+    x2: number;
+    xMid: number;
+    y: number;
+    barHeight: number;
+  } | null = null;
   data.forEach((d) => {
     const x1 = xScale(d.min);
     const x2 = xScale(d.max);
@@ -414,9 +433,25 @@ export async function exportChartToPng(
 
       // ── Collect annotation data for drawing outside clip ────────────
       if (isPairSelected) {
-        const midValue = midPredict ? midPredict(d.y) : (d.min + d.max) / 2;
+        // Calculate V using the formula: Vn = (C5% - Cn) + (R5% - Rn) / 2
+        let midValue: number;
+        if (c5Value !== null && r5Value !== null) {
+          midValue = (c5Value - d.min) + (r5Value - d.max) / 2;
+          // If V is negative, use simple average as fallback
+          if (midValue < 0) midValue = (d.min + d.max) / 2;
+        } else {
+          midValue = (d.min + d.max) / 2;
+        }
         const xMid = xScale(midValue);
-        selectedAnnotation = { x1, x2, xMid, y, barHeight: expanded ? CHART_CONFIG.BAR_HEIGHT : CHART_CONFIG.MINIMAL_BAR_HEIGHT };
+        selectedAnnotation = {
+          x1,
+          x2,
+          xMid,
+          y,
+          barHeight: expanded
+            ? CHART_CONFIG.BAR_HEIGHT
+            : CHART_CONFIG.MINIMAL_BAR_HEIGHT,
+        };
       }
     }
   });
@@ -450,7 +485,8 @@ export async function exportChartToPng(
       steps = 80,
       clampZero = true,
     ): { x: number; y: number }[] => {
-      if (rawData.length < 3) return rawData.map(([x, y]) => ({ x: xScale(x), y: yScale(y) }));
+      if (rawData.length < 3)
+        return rawData.map(([x, y]) => ({ x: xScale(x), y: yScale(y) }));
       const regression = regressionPoly()
         .x((d: [number, number]) => d[1])
         .y((d: [number, number]) => d[0])
@@ -496,7 +532,10 @@ export async function exportChartToPng(
     }
 
     if (showMidCurve) {
-      const raw: [number, number][] = sorted.map((d) => [(d.min + d.max) / 2, d.y]);
+      const raw: [number, number][] = sorted.map((d) => [
+        (d.min + d.max) / 2,
+        d.y,
+      ]);
       drawTrendCurve(buildTrendPoints(raw));
     }
   }
@@ -559,9 +598,8 @@ export async function exportChartToPng(
     ctx.fillStyle = "#ffffff";
     ctx.fillText("R", x2, labelY);
 
-    // Purple arrow from C (min) to PPp 5% line
+    // Purple arrow from C (min) to PPp 5% line - aligned with the bar
     if (p5LineX !== null && Math.abs(p5LineX - x1) > labelR) {
-      const arrowY = y + barHeight / 2 + 6;
       const arrowLeft = Math.min(x1, p5LineX);
       const arrowRight = Math.max(x1, p5LineX);
       const headSize = 4;
@@ -570,36 +608,36 @@ export async function exportChartToPng(
       ctx.fillStyle = "#7B2D8E";
       ctx.lineWidth = 1;
 
-      // Line
+      // Line - aligned with bar center (y)
       ctx.beginPath();
-      ctx.moveTo(arrowLeft, arrowY);
-      ctx.lineTo(arrowRight, arrowY);
+      ctx.moveTo(arrowLeft, y);
+      ctx.lineTo(arrowRight, y);
       ctx.stroke();
 
       // Left arrowhead
       ctx.beginPath();
-      ctx.moveTo(arrowLeft, arrowY);
-      ctx.lineTo(arrowLeft + headSize, arrowY - headSize / 2);
-      ctx.lineTo(arrowLeft + headSize, arrowY + headSize / 2);
+      ctx.moveTo(arrowLeft, y);
+      ctx.lineTo(arrowLeft + headSize, y - headSize / 2);
+      ctx.lineTo(arrowLeft + headSize, y + headSize / 2);
       ctx.closePath();
       ctx.fill();
 
       // Right arrowhead
       ctx.beginPath();
-      ctx.moveTo(arrowRight, arrowY);
-      ctx.lineTo(arrowRight - headSize, arrowY - headSize / 2);
-      ctx.lineTo(arrowRight - headSize, arrowY + headSize / 2);
+      ctx.moveTo(arrowRight, y);
+      ctx.lineTo(arrowRight - headSize, y - headSize / 2);
+      ctx.lineTo(arrowRight - headSize, y + headSize / 2);
       ctx.closePath();
       ctx.fill();
 
-      // "P" label at midpoint of arrow
+      // "P" label at midpoint of arrow, aligned with the bar
       const arrowMidX = (arrowLeft + arrowRight) / 2;
       ctx.fillStyle = "#7B2D8E";
       ctx.beginPath();
-      ctx.arc(arrowMidX, arrowY, labelR, 0, Math.PI * 2);
+      ctx.arc(arrowMidX, y, labelR, 0, Math.PI * 2);
       ctx.fill();
       ctx.fillStyle = "#ffffff";
-      ctx.fillText("P", arrowMidX, arrowY);
+      ctx.fillText("P", arrowMidX, y);
     }
 
     ctx.restore();
@@ -690,11 +728,7 @@ export async function exportChartToPng(
       ctx.font = "bold 10px sans-serif";
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
-      ctx.fillText(
-        cls.label,
-        barX + barWidth / 2,
-        bandTop + bandH / 2,
-      );
+      ctx.fillText(cls.label, barX + barWidth / 2, bandTop + bandH / 2);
 
       ctx.globalAlpha = 1;
     });
@@ -716,8 +750,7 @@ export async function exportChartToPng(
   ctx.restore();
 
   // X-axis label
-  const labelX =
-    xAxisLabel ?? UNIT_LABELS[unit] ?? "Carbono Embutido";
+  const labelX = xAxisLabel ?? UNIT_LABELS[unit] ?? "Carbono Embutido";
   ctx.font = "11px sans-serif";
   ctx.fillStyle = DEFAULT_COLORS.TEXT;
   ctx.textAlign = "center";

--- a/web/frontend/src/components/summaryVariants/floors.tsx
+++ b/web/frontend/src/components/summaryVariants/floors.tsx
@@ -287,6 +287,9 @@ const FloorSummary = ({
             showBaseline
             showTop5Line
             showProcelScale
+            showMaxCurve
+            showMinCurve
+            showMidCurve
           />
         ) : (
           <D3GradientRangeLineChart

--- a/web/frontend/src/components/summaryVariants/projects.tsx
+++ b/web/frontend/src/components/summaryVariants/projects.tsx
@@ -1,5 +1,6 @@
 import { IBenchmarkResponse } from "@/actions/benchmarks/types";
 import { useSummary } from "@/context/summaryContext";
+import { useTranslation } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { unitsOfMeasure } from "@/utils/unitsOfMeasure";
 import { useEffect, useMemo, useState } from "react";
@@ -12,7 +13,6 @@ import Legend from "./components/Legend";
 import ListItem from "./components/ListItem";
 import { useChartType } from "./hooks/useChartType";
 import { barColors, normalizeBenchmarkSeries, recalculateY } from "./utils";
-import { useTranslation } from "@/i18n";
 
 type ProjectsSummaryProps = {
   projects: any[];
@@ -226,6 +226,9 @@ const ProjectsSummary = ({
             showBaseline
             showTop5Line
             showProcelScale
+            showMaxCurve
+            showMinCurve
+            showMidCurve
           />
         ) : (
           <D3GradientRangeLineChart

--- a/web/frontend/src/components/summaryVariants/technologies.tsx
+++ b/web/frontend/src/components/summaryVariants/technologies.tsx
@@ -264,6 +264,9 @@ const SimulationsSummary = ({
             showBaseline
             showTop5Line
             showProcelScale
+            showMaxCurve
+            showMinCurve
+            showMidCurve
           />
         ) : (
           <D3GradientRangeLineChart

--- a/web/frontend/src/components/summaryVariants/units.tsx
+++ b/web/frontend/src/components/summaryVariants/units.tsx
@@ -289,6 +289,9 @@ const UnitsSummary = ({
             showBaseline
             showTop5Line
             showProcelScale
+            showMaxCurve
+            showMinCurve
+            showMidCurve
           />
         ) : (
           <D3GradientRangeLineChart


### PR DESCRIPTION
This pull request makes significant improvements to the `D3GradientRangeChart` component and the chart export logic, focusing on more accurate rendering, better handling of container measurements, improved visual clarity, and enhanced percentile and regression calculations. The changes result in more reliable and visually informative charts, especially for edge cases and when rendering/exporting charts with percentile lines and regression curves.

**Key improvements and fixes:**

**Chart rendering accuracy and robustness:**
- Improved container measurement logic: Ensures the chart only draws when container dimensions are valid, adds a retry mechanism if initial measurement fails, and triggers redraws when container size or PROCEL scale visibility changes. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL255-R274) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL136-R137) [[3]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR1189-R1198)
- Drawing now skips if width or height is zero, preventing rendering glitches before measurement.
- Initial chart draw is delayed slightly to ensure container measurement is complete. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL1031-R1081) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR1145)

**Visual and UX improvements:**
- PROCEL scale margin and band width reduced for better fit and clarity. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL125-R125) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL919-R966)
- Baseline and 5% line visuals improved: removed dashed lines, simplified labeling, and updated color schemes for arrows and lines for better distinction and accessibility. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL755-L760) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL769-R816) [[3]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL784-R831) [[4]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL706-R769)
- Bar rendering updated: selected bars are now visually split at a regression-predicted midpoint (blue and orange halves), with regression computed only when enough data is present. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR598-R610) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR691-R718)

**Percentile and regression logic enhancements:**
- 5th percentile (C5% and R5%) values are now calculated separately for min and max, used for more accurate placement of reference lines and for V calculation in exports. [[1]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L283-R299) [[2]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L417-R454)
- Midpoint regression and trend curve logic improved for both on-screen and exported charts, including fallbacks for small datasets. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR598-R610) [[2]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L298-R311) [[3]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L453-R489) [[4]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L499-R538)

**Exported chart improvements:**
- Exported charts now use the updated percentile and regression logic, with arrows and labels aligned visually with the bars, and "P" annotation positioned at the bar center. [[1]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L562-L564) [[2]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L573-R640)
- Minor formatting and code consistency improvements for exported chart drawing routines. [[1]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L350-R369) [[2]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L693-R731) [[3]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L719-R753)

These changes collectively make the chart component and its exports more robust, visually consistent, and accurate in representing statistical information.

---

**References:**
- Chart rendering and measurement: [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL255-R274) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL136-R137) [[3]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR1189-R1198) [[4]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR483-R484) [[5]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL1031-R1081) [[6]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR1145)
- Visual/UX improvements: [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL125-R125) [[2]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL919-R966) [[3]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL755-L760) [[4]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL769-R816) [[5]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL784-R831) [[6]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bL706-R769) [[7]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR691-R718)
- Percentile/regression logic: [[1]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L283-R299) [[2]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L417-R454) [[3]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR598-R610) [[4]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L298-R311) [[5]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L453-R489) [[6]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L499-R538)
- Export chart improvements: [[1]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L562-L564) [[2]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L573-R640) [[3]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L350-R369) [[4]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L693-R731) [[5]](diffhunk://#diff-063f536f499cfd5680bc0369a3da5eba6c47b9a2a2865f06983652334554de60L719-R753)