### PR TITLE
✨ show select item name in benchmark

### DIFF
--- a/web/frontend/src/components/charts/d3chart.tsx
+++ b/web/frontend/src/components/charts/d3chart.tsx
@@ -107,6 +107,8 @@ type D3GradientRangeChartProps = {
   showMinCurve?: boolean;
   /** Show dashed curve for Vn = (C5% - Cn) + (R5% - Rn) / 2 */
   showMidCurve?: boolean;
+  /** Show project name next to the selected bar */
+  showProjectName?: boolean;
 };
 // Custom hooks
 const useChartDimensions = (
@@ -217,6 +219,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
   showMaxCurve = false,
   showMinCurve = false,
   showMidCurve = false,
+  showProjectName = false,
   ...props
 }) => {
   const { isExpanded } = useSummary();
@@ -796,6 +799,53 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
       }
     });
 
+    // Draw project names for selected bars
+    if (showProjectName) {
+      data.forEach((d) => {
+        const isMinSelected = selectedMinBarIds.has(String(d.minId ?? d.id));
+        const isMaxSelected = selectedMaxBarIds.has(String(d.maxId ?? d.id));
+        const isPairSelected = isMinSelected && isMaxSelected;
+        
+        if (isPairSelected && d.label) {
+          const x1 = newXScale(d.min);
+          const x2 = newXScale(d.max);
+          const y = newYScale(d.y);
+          
+          // Skip if outside visible area
+          if (x2 < 0 || x1 > _width || y < 0 || y > _height) return;
+          
+          // Position text to the right of the max point
+          const textX = x2 + 10;
+          const textY = y;
+          
+          ctx.save();
+          ctx.font = isExpanded ? "12px sans-serif" : "10px sans-serif";
+          ctx.fillStyle = "#111827";
+          ctx.textAlign = "left";
+          ctx.textBaseline = "middle";
+          
+          // Add a semi-transparent background for better readability
+          const textMetrics = ctx.measureText(d.label);
+          const textWidth = textMetrics.width;
+          const textHeight = isExpanded ? 16 : 14;
+          const padding = 4;
+          
+          ctx.fillStyle = "rgba(255, 255, 255, 0.85)";
+          ctx.fillRect(
+            textX - padding,
+            textY - textHeight / 2,
+            textWidth + padding * 2,
+            textHeight
+          );
+          
+          // Draw the text
+          ctx.fillStyle = "#111827";
+          ctx.fillText(d.label, textX, textY);
+          ctx.restore();
+        }
+      });
+    }
+
     // Draw baseline on top of all points
     if (baselineY !== null) {
       ctx.save();
@@ -1021,6 +1071,7 @@ const D3GradientRangeChart: React.FC<D3GradientRangeChartProps> = ({
     showMaxCurve,
     showMinCurve,
     showMidCurve,
+    showProjectName,
     updateBrushCount,
   ]);
 

--- a/web/frontend/src/components/charts/d3chartLine.tsx
+++ b/web/frontend/src/components/charts/d3chartLine.tsx
@@ -1,19 +1,19 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { useSummary } from "@/context/summaryContext";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useTranslation } from "@/i18n";
+import { Translations } from "@/i18n/translations/pt-BR";
 import { cn } from "@/lib/utils";
 import * as d3 from "d3";
 import { regressionPoly } from "d3-regression";
 import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
 } from "react";
 import Divider from "../ui/divider";
-import { useTranslation } from "@/i18n";
-import { Translations } from "@/i18n/translations/pt-BR";
 
 const UNIT_LABELS = (t: Translations) => ({
   co2: `${t.benchmark.chartTypes.cumulativeFraction.yAxisLabel} (kg CO₂/m²)`,
@@ -67,6 +67,7 @@ type D3GradientRangeChartProps = {
   customData?: any;
   unit?: string;
   summary?: boolean;
+  showProjectName?: boolean;
 };
 
 type TooltipData = {
@@ -179,6 +180,7 @@ const D3GradientRangeLineChart: React.FC<D3GradientRangeChartProps> = ({
   overrideDimensions = false,
   unit = "",
   summary = true,
+  showProjectName = false,
   ...props
 }) => {
   const {t} = useTranslation(); 
@@ -857,13 +859,13 @@ const D3GradientRangeLineChart: React.FC<D3GradientRangeChartProps> = ({
           .text(`${d.label} -> `)
           .attr("id", `bar-label-min-${d.id}`);
 
-        // Project name (expanded only)
-        if (isExpanded) {
+        // Project name (controlled by showProjectName prop)
+        if (showProjectName) {
           g.append("text")
             .attr("x", (y1 + y2) / 2)
             .attr("y", x + 5)
             .attr("text-anchor", "middle")
-            .attr("font-size", 14)
+            .attr("font-size", isExpanded ? 14 : 12)
             .attr("font-weight", "bold")
             .attr("fill", "#FFF")
             .text(`${d.label}`)
@@ -898,6 +900,7 @@ const D3GradientRangeLineChart: React.FC<D3GradientRangeChartProps> = ({
     yScale,
     colorScale,
     shouldHideBars,
+    showProjectName,
   ]);
 
   const labelY =

--- a/web/frontend/src/components/summaryVariants/floors.tsx
+++ b/web/frontend/src/components/summaryVariants/floors.tsx
@@ -45,6 +45,7 @@ const FloorSummary = ({
     }));
   const { isExpanded } = useSummary();
 
+  console.log("filteredFloors", filteredFloors);
   const newItems = filteredFloors.map((el) => {
     return {
       co2: {
@@ -52,14 +53,14 @@ const FloorSummary = ({
         y: 0,
         min: el.co2_min,
         max: el.co2_max,
-        label: el.group_name,
+        label: el.floor_group,
       },
       energy: {
         id: el.id,
         y: 0,
         min: el.energy_min,
         max: el.energy_max,
-        label: el.group_name,
+        label: el.floor_group,
       },
     };
   });
@@ -159,6 +160,7 @@ const FloorSummary = ({
     maxValue,
   );
 
+  console.log("newData", newItems);
   return (
     <>
       <div className="w-full flex gap-2 mb-4">
@@ -290,6 +292,7 @@ const FloorSummary = ({
             showMaxCurve
             showMinCurve
             showMidCurve
+            showProjectName
           />
         ) : (
           <D3GradientRangeLineChart

--- a/web/frontend/src/components/summaryVariants/projects.tsx
+++ b/web/frontend/src/components/summaryVariants/projects.tsx
@@ -18,12 +18,14 @@ type ProjectsSummaryProps = {
   projects: any[];
   data: IBenchmarkResponse;
   someSelected: boolean;
+  showProjectName?: boolean;
 };
 
 const ProjectsSummary = ({
   projects,
   data,
   someSelected,
+  showProjectName = true,
 }: ProjectsSummaryProps) => {
   const [type, setType] = useState<"co2" | "energy">("co2");
   const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
@@ -229,12 +231,14 @@ const ProjectsSummary = ({
             showMaxCurve
             showMinCurve
             showMidCurve
+            showProjectName={showProjectName}
           />
         ) : (
           <D3GradientRangeLineChart
             data={newData}
             selectedBars={selectedProjects}
             unit={type}
+            showProjectName={showProjectName}
           />
         )}
       </div>

--- a/web/frontend/src/components/summaryVariants/technologies.tsx
+++ b/web/frontend/src/components/summaryVariants/technologies.tsx
@@ -267,6 +267,7 @@ const SimulationsSummary = ({
             showMaxCurve
             showMinCurve
             showMidCurve
+            showProjectName
           />
         ) : (
           <D3GradientRangeLineChart

--- a/web/frontend/src/components/summaryVariants/units.tsx
+++ b/web/frontend/src/components/summaryVariants/units.tsx
@@ -292,6 +292,7 @@ const UnitsSummary = ({
             showMaxCurve
             showMinCurve
             showMidCurve
+            showProjectName
           />
         ) : (
           <D3GradientRangeLineChart


### PR DESCRIPTION
This pull request adds the ability to display project names next to selected bars in both bar and line gradient range charts across several summary components. The new feature is controlled by a `showProjectName` prop, which is now threaded through relevant chart and summary components. Additionally, some minor refactoring and debugging code was introduced.

**Feature: Show Project Name on Charts**

* Added a new `showProjectName` prop to `D3GradientRangeChartProps` and `D3GradientRangeLineChartProps` in both `d3chart.tsx` and `d3chartLine.tsx`, allowing charts to optionally display the project name next to selected bars or lines. [[1]](diffhunk://#diff-99b9b28ea44a80ff853613a364f439f0552d294ad1a1de0160fa4be7e7aaf19bR110-R111) [[2]](diffhunk://#diff-79e695b1ccb71f626edd5f84461045ca022120403a9c644f38ebf232e8b612bdR70)
* Implemented logic in `D3GradientRangeChart` to draw project names with a styled background next to selected bars when `showProjectName` is enabled.
* Updated `D3GradientRangeLineChart` to render project names above selected lines when `showProjectName` is enabled, with font size adapting to the expanded state.

**Prop Threading and Usage in Summary Components**

* Passed the `showProjectName` prop through summary components (`ProjectsSummary`, `FloorSummary`, `SimulationsSummary`, `UnitsSummary`) to the chart components, enabling the feature where appropriate. [[1]](diffhunk://#diff-469d32ffa87f1ff9c310d9d129cfda032fc473c066eb858a2a1db97619221669R21-R28) [[2]](diffhunk://#diff-469d32ffa87f1ff9c310d9d129cfda032fc473c066eb858a2a1db97619221669R234-R241) [[3]](diffhunk://#diff-c8cfe7331ae13f2f59feac32af7acd72f1b1288ee52c0d44e5ca54ab80aef0b4R295) [[4]](diffhunk://#diff-74582d299d0c8a0b14aa257c569881346f00341f6ce511cb17de17b1c07a549bR270) [[5]](diffhunk://#diff-27d03633dbc6bb0d8e437744cb52c9e8f729809c092089b0a11ed7681cb4082eR295)

**Minor Refactoring and Debugging**

* Updated the label property in floor summary data mapping from `group_name` to `floor_group` for clarity.
* Added console logging for debugging filtered floor data and new items in `FloorSummary`. [[1]](diffhunk://#diff-c8cfe7331ae13f2f59feac32af7acd72f1b1288ee52c0d44e5ca54ab80aef0b4R48-R63) [[2]](diffhunk://#diff-c8cfe7331ae13f2f59feac32af7acd72f1b1288ee52c0d44e5ca54ab80aef0b4R163)
* Cleaned up unused imports in `d3chartLine.tsx`. [[1]](diffhunk://#diff-79e695b1ccb71f626edd5f84461045ca022120403a9c644f38ebf232e8b612bdR4-R5) [[2]](diffhunk://#diff-79e695b1ccb71f626edd5f84461045ca022120403a9c644f38ebf232e8b612bdL15-L16)