### PR TITLE
fix: Update tooltip content for duplicate module

### DIFF
--- a/web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/constructive-technologies/index.tsx
+++ b/web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/constructive-technologies/index.tsx
@@ -480,7 +480,7 @@ function RouteComponent() {
                 });
               }}
               componentTrigger={
-                <SimpleTooltip content={t.modules.deleteTitle} side="bottom">
+                <SimpleTooltip content={t.modules.duplicateTitle} side="bottom">
                   <Button variant="ghost" size="icon" disabled={isDeletingTec}>
                     {isDeletingTec ? (
                       <Loader2 className="h-4 w-4 animate-spin" />


### PR DESCRIPTION
This pull request makes a minor UI text update to the tooltip in the constructive technologies page. The tooltip now correctly displays the action as "duplicate" instead of "delete" for the corresponding button.

* UI Text Fix:
  * Changed the tooltip content for the action button from the delete title to the duplicate title in `index.tsx`, ensuring the tooltip accurately reflects the button's purpose.