### PR TITLE
fix: Update tooltip translation for module duplication

### DIFF
--- a/web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/constructive-technologies/index.tsx
+++ b/web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/constructive-technologies/index.tsx
@@ -480,7 +480,7 @@ function RouteComponent() {
                 });
               }}
               componentTrigger={
-                <SimpleTooltip content={t.modules.deleteTitle} side="bottom">
+                <SimpleTooltip content={t.modules.duplicateTitle} side="bottom">
                   <Button variant="ghost" size="icon" disabled={isDeletingTec}>
                     {isDeletingTec ? (
                       <Loader2 className="h-4 w-4 animate-spin" />


### PR DESCRIPTION
This pull request makes a minor UI improvement by updating the tooltip text for a button in the constructive technologies unit page. The tooltip now correctly indicates the button's function as "duplicate" instead of "delete".

* Changed the `SimpleTooltip` content from `t.modules.deleteTitle` to `t.modules.duplicateTitle` to accurately reflect the button's purpose.