### PR TITLE
redir www

### DIFF
--- a/remote/production/Caddyfile
+++ b/remote/production/Caddyfile
@@ -5,3 +5,7 @@
 app.bipc.org.br {
   reverse_proxy localhost:4000
 }
+
+www.app.bipc.org.br {
+  redir https://app.bipc.org.br{uri} permanent
+}

--- a/remote/stage/Caddyfile
+++ b/remote/stage/Caddyfile
@@ -5,3 +5,7 @@
 stage.bipc.org.br {
   reverse_proxy localhost:4000
 }
+
+www.stage.bipc.org.br {
+  redir https://stage.bipc.org.br{uri} permanent
+}


### PR DESCRIPTION
This pull request updates the Caddy server configuration files to add permanent redirects from the `www.` subdomain to the non-`www.` version for both production and staging environments. This ensures users are always directed to the canonical domain, which is important for consistency and SEO.

**Caddyfile redirect configuration:**

* Added a permanent redirect from `www.app.bipc.org.br` to `app.bipc.org.br` in the production Caddyfile.
* Added a permanent redirect from `www.stage.bipc.org.br` to `stage.bipc.org.br` in the staging Caddyfile.