### PR TITLE
add phase as_built

### DIFF
--- a/internal/data/projects.go
+++ b/internal/data/projects.go
@@ -18,7 +18,7 @@ var (
 		"MA", "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI",
 		"RJ", "RN", "RS", "RO", "RR", "SC", "SP", "SE", "TO"}
 
-	phases = []string{"preliminary_study", "not_defined", "basic_project", "executive_project", "released_for_construction"}
+	phases = []string{"preliminary_study", "not_defined", "basic_project", "executive_project", "released_for_construction", "as_built"}
 
 	PhaseMap = map[string]string{
 		"preliminary_study":         "Estudo Preliminar",


### PR DESCRIPTION
This pull request makes a minor update to the list of project phases in the `internal/data/projects.go` file. The change adds a new phase, `"as_built"`, to the existing list of phases. 

- Added `"as_built"` to the `phases` slice, ensuring the system can now recognize and handle this new project phase.