### PR TITLE
fix: update warning messages for location identification in translations

### DIFF
--- a/web/frontend/src/i18n/translations/en.ts
+++ b/web/frontend/src/i18n/translations/en.ts
@@ -910,7 +910,7 @@ export const en: Translations = {
     unmatchedWarning: "without precise location",
     unmatchedTooltip:
       "Projects registered with inconsistent municipality (city from another state)",
-    noStateWarning: "without state and municipality identification",
+    noStateWarning: "projects from benchmark without location",
     noStateTooltip:
       "Projects without a registered state and municipality are not shown on the map",
     clickStateHint:

--- a/web/frontend/src/i18n/translations/pt-BR.ts
+++ b/web/frontend/src/i18n/translations/pt-BR.ts
@@ -913,7 +913,8 @@ export const ptBR = {
     unmatchedWarning: "sem localização precisa",
     unmatchedTooltip:
       "Projetos cadastrados com município inconsistente (cidade de outro estado)",
-    noStateWarning: "sem identificação de estado e município",
+    noStateWarning:
+      "empreendimentos do benchmark sem identificação de localidade",
     noStateTooltip:
       "Empreendimentos sem estado e município cadastrados não são exibidos no mapa",
     clickStateHint:

--- a/web/frontend/src/routes/(public)/benchmark.tsx
+++ b/web/frontend/src/routes/(public)/benchmark.tsx
@@ -1,10 +1,13 @@
 import { getProjectsBenchmark } from "@/actions/benchmarks/getProjects";
-import { IBenchmarkSeries, IBenchmarkSeriesPoint } from "@/actions/benchmarks/types";
+import {
+  IBenchmarkSeries,
+  IBenchmarkSeriesPoint,
+} from "@/actions/benchmarks/types";
 import Logo from "@/assets/logo_full.svg";
 import BrazilMapChart, {
   type MapChartStats,
 } from "@/components/charts/brazilMapChart";
-import D3RangeChart from '@/components/charts/d3chartCUM';
+import D3RangeChart from "@/components/charts/d3chartCUM";
 import D3GradientRangeLineChart, {
   SeriesPoint,
 } from "@/components/charts/d3chartLine";
@@ -38,12 +41,17 @@ type BenchmarkPoint = {
 };
 
 // Para o scatter chart: ordenar por y e parear min+max pela ordem
-const normalizeBenchmarkSeries = (series?: IBenchmarkSeries | IBenchmarkSeriesPoint[] | undefined): BenchmarkPoint[] => {
+const normalizeBenchmarkSeries = (
+  series?: IBenchmarkSeries | IBenchmarkSeriesPoint[] | undefined,
+): BenchmarkPoint[] => {
   if (!series) return [];
-  if (series instanceof Array && series.length > 0 && "value" in series[0]) return series as unknown as BenchmarkPoint[]; // Apenas para material, que já vem pareado e ordenado
+  if (series instanceof Array && series.length > 0 && "value" in series[0])
+    return series as unknown as BenchmarkPoint[]; // Apenas para material, que já vem pareado e ordenado
 
-  const sortByY = (a: IBenchmarkSeries["min"][number], b: IBenchmarkSeries["min"][number]) =>
-    a.y - b.y;
+  const sortByY = (
+    a: IBenchmarkSeries["min"][number],
+    b: IBenchmarkSeries["min"][number],
+  ) => a.y - b.y;
   const minList = [...((series as IBenchmarkSeries).min || [])].sort(sortByY);
   const maxList = [...((series as IBenchmarkSeries).max || [])].sort(sortByY);
   const pairCount = Math.min(minList.length, maxList.length);
@@ -103,8 +111,14 @@ function RouteComponent() {
   const hasActiveFilter =
     activeBuildFilter.technology.length > 0 || !!activeBuildFilter.floors.get();
 
-  const mapData = useBenchmarkMapData(baseResponse, type === "material" ? "co2" : type);
-  const filteredMapData = useBenchmarkMapData(filteredResponse, type === "material" ? "co2" : type);
+  const mapData = useBenchmarkMapData(
+    baseResponse,
+    type === "material" ? "co2" : type,
+  );
+  const filteredMapData = useBenchmarkMapData(
+    filteredResponse,
+    type === "material" ? "co2" : type,
+  );
   const activeMapResult =
     hasActiveFilter && filteredMapData.states.length > 0
       ? filteredMapData
@@ -125,19 +139,39 @@ function RouteComponent() {
 
   // Line chart: séries independentes sem join por id
   const baseMinSeries = useMemo(
-    () => toSeriesPoints(type !== 'material' ? baseResponse?.data?.benchmark?.[type]?.min : undefined),
+    () =>
+      toSeriesPoints(
+        type !== "material"
+          ? baseResponse?.data?.benchmark?.[type]?.min
+          : undefined,
+      ),
     [baseResponse, type],
   );
   const baseMaxSeries = useMemo(
-    () => toSeriesPoints(type !== 'material' ? baseResponse?.data?.benchmark?.[type]?.max : undefined),
+    () =>
+      toSeriesPoints(
+        type !== "material"
+          ? baseResponse?.data?.benchmark?.[type]?.max
+          : undefined,
+      ),
     [baseResponse, type],
   );
   const filteredMinSeries = useMemo(
-    () => toSeriesPoints(type !== 'material' ? filteredResponse?.data?.benchmark?.[type]?.min : undefined),
+    () =>
+      toSeriesPoints(
+        type !== "material"
+          ? filteredResponse?.data?.benchmark?.[type]?.min
+          : undefined,
+      ),
     [filteredResponse, type],
   );
   const filteredMaxSeries = useMemo(
-    () => toSeriesPoints(type !== 'material' ? filteredResponse?.data?.benchmark?.[type]?.max : undefined),
+    () =>
+      toSeriesPoints(
+        type !== "material"
+          ? filteredResponse?.data?.benchmark?.[type]?.max
+          : undefined,
+      ),
     [filteredResponse, type],
   );
 
@@ -186,9 +220,9 @@ function RouteComponent() {
                     <SelectValue placeholder={t.benchmark.chartPlaceholder} />
                   </SelectTrigger>
                   <SelectContent defaultValue={"co2"}>
-                    <SelectItem value="trend">
+                    {/* <SelectItem value="trend">
                       {t.benchmark.chartTrend}
-                    </SelectItem>
+                    </SelectItem> */}
                     <SelectItem value="co2">
                       {t.benchmark.chartBenchmark}
                     </SelectItem>
@@ -203,7 +237,9 @@ function RouteComponent() {
                   </h2>
                   <FilterTabs
                     tabs={["co2", "energy", "material"]}
-                    onTabSelect={(tab) => setType(tab as "co2" | "energy" | "material")}
+                    onTabSelect={(tab) =>
+                      setType(tab as "co2" | "energy" | "material")
+                    }
                     selectedTab={type}
                     className="!h-10 !py-0"
                   />
@@ -301,8 +337,20 @@ function RouteComponent() {
                   showMaxCurve={type !== "material"}
                   showMinCurve={type !== "material"}
                   variant={type === "material" ? "cumulative" : "range"}
-                  xAxisLabel={t.benchmark.chartTypes[type === 'co2' || type === 'energy' ? 'cumulativeFraction' : 'material'][type === 'co2' ? 'xAxisLabelCarbon' : 'xAxisLabelEnergy']}
-                  yAxisLabel={t.benchmark.chartTypes[type === 'co2' || type === 'energy' ? 'cumulativeFraction' : 'material'].yAxisLabel}
+                  xAxisLabel={
+                    t.benchmark.chartTypes[
+                      type === "co2" || type === "energy"
+                        ? "cumulativeFraction"
+                        : "material"
+                    ][type === "co2" ? "xAxisLabelCarbon" : "xAxisLabelEnergy"]
+                  }
+                  yAxisLabel={
+                    t.benchmark.chartTypes[
+                      type === "co2" || type === "energy"
+                        ? "cumulativeFraction"
+                        : "material"
+                    ].yAxisLabel
+                  }
                 />
               )}
             </div>


### PR DESCRIPTION
Related issue:
- https://github.com/Benchmark-CO2/bipc/issues/338

This pull request introduces support for "material" consumption data throughout the benchmarking system, alongside CO2 and energy. It updates the data model, SQL queries, API handlers, and supporting functions to aggregate, process, and expose material consumption in all relevant endpoints and reports. Additionally, it adds a backfill mechanism to populate missing module consumption data at application startup.

**Support for material consumption in benchmarks:**

* Added `Material` field to `BenchmarkData`, updated all related structs (including `BenchmarkSeries`), and extended all relevant API handler logic to include material values. [[1]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4R37-R46) [[2]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L52-R68) [[3]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4R82-R107) [[4]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4R121-R150) [[5]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L160-R201) [[6]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L181-R222) [[7]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L203-R240) [[8]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L214-R251) [[9]](diffhunk://#diff-5448ab82aeca81db5c1c19de8bca10dbf30606a3a4326f44d27ee63cfb2b5a7bR76) [[10]](diffhunk://#diff-5448ab82aeca81db5c1c19de8bca10dbf30606a3a4326f44d27ee63cfb2b5a7bR92-R102)
* Updated SQL queries and data loading logic in `internal/data/benchmark.go` to aggregate and return material data for floors, units, and projects. [[1]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL41-R42) [[2]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL62-R71) [[3]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfR83) [[4]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL105-R109) [[5]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL120-R125) [[6]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL130-R136) [[7]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL139-R146) [[8]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfR166-R174) [[9]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfR186) [[10]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL309-R320) [[11]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL340-R352) [[12]](diffhunk://#diff-9fcba2d9465bb11ffac600e8f4543fa0b3f191d58e320ffd8f4d2e9e961884dfL350-R363)
* Modified ranking and aggregation functions (e.g., `separateConsumption`, `buildBenchmarkData`) to handle material series and values. [[1]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L52-R68) [[2]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4R82-R107) [[3]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4R121-R150) [[4]](diffhunk://#diff-b57da4af7d96abc4e646ef06bba86220282fd0b993e60fbe5a48aa1a2608b0d4L142-R186)

**Backfill and data migration logic:**

* Added `cmd/api/consumption_sync.go` with functions to backfill missing module consumption data, and integrated this backfill step into application startup in `main.go`. [[1]](diffhunk://#diff-097729c5adafafaebcb6e494d0a995012f93f29514ab908291bc13d3899cb146R1-R68) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afR108-R120) [[3]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL128-R141)

**Other updates:**

* Ensured that module duplication copies over material totals and properly initializes material values in new modules. [[1]](diffhunk://#diff-5448ab82aeca81db5c1c19de8bca10dbf30606a3a4326f44d27ee63cfb2b5a7bR76) [[2]](diffhunk://#diff-5448ab82aeca81db5c1c19de8bca10dbf30606a3a4326f44d27ee63cfb2b5a7bR92-R102)
* Updated benchmark report generation to use the new `BenchmarkSeries` structure.

These changes ensure that material consumption is now a first-class metric in the benchmarking system, available in all relevant queries, endpoints, and reports.