### PR TITLE
fix: Disciplines UX and Benchmark drawer height

### DIFF
--- a/web/frontend/src/components/layout/project/collaborator-view.tsx
+++ b/web/frontend/src/components/layout/project/collaborator-view.tsx
@@ -1,13 +1,11 @@
 import { Button } from "@/components/ui/button";
-import { PencilIcon, PlusIcon, TrashIcon, UserCheck } from "lucide-react";
-import DrawerFormDisciplines from "../drawer-form-disciplines";
+import { TrashIcon, UserCheck } from "lucide-react";
 import DialogTransferOwnership from "../dialog-transfer-ownership";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { getProjectCollaborators } from "@/actions/projectCollaborators/getProjectCollaborators";
 import DrawerInvite from "../drawer-invite";
 import ModalConfirmDelete from "../modal-confirm-delete";
 import { deleteProjectCollaborator } from "@/actions/projectCollaborators/deleteProjectCollaborator";
-import { deleteDiscipline } from "@/actions/disciplines/deleteDiscipline";
 import { toast } from "sonner";
 import { queryClient } from "@/utils/queryClient";
 import { useAuth } from "@/hooks/useAuth";
@@ -65,7 +63,12 @@ const CollaboratorsView = ({
       });
 
       if (deletedCollaborator?.email === email) {
-        navigate({ to: "/new_projects" });
+        navigate({
+          to: "/new_projects",
+          search: {
+            activationRequired: false,
+          },
+        });
       }
     },
     onError: (error) => {
@@ -75,29 +78,6 @@ const CollaboratorsView = ({
       });
     },
   });
-
-  const { mutate: mutateDeleteDiscipline, isPending: isDeletingDiscipline } =
-    useMutation({
-      mutationFn: (disciplineId: string) =>
-        deleteDiscipline(projectId, disciplineId),
-      onSuccess: () => {
-        toast.success(t.collaboratorsView.successRemoveDiscipline, {
-          duration: 5000,
-        });
-        queryClient.invalidateQueries({
-          queryKey: ["project-collaborators", projectId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ["project-permissions", projectId],
-        });
-      },
-      onError: (error) => {
-        toast.error(t.collaboratorsView.errorRemoveDiscipline, {
-          description: parseApiError(error, t),
-          duration: 5000,
-        });
-      },
-    });
 
   const { mutate: mutateDeleteInvite, isPending: isDeletingInvite } =
     useMutation({
@@ -120,8 +100,6 @@ const CollaboratorsView = ({
     });
 
   const collaborators = collaboratorsData?.data?.data?.collaborators || [];
-  const roles = collaboratorsData?.data?.data?.roles || [];
-  const rolesNames = roles.filter((r) => !r.is_protected).map((r) => r.name);
 
   const sortedCollaborators = [...collaborators].sort((a, b) => {
     const aIsAdmin = (a.roles as unknown as string[])?.some(
@@ -146,104 +124,6 @@ const CollaboratorsView = ({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="bg-white dark:bg-gray-800 rounded-lg dark:border-gray-700">
-        <div className="flex justify-between items-center mb-3">
-          <h2 className="text-h2 text-primary dark:text-gray-200">
-            {t.collaboratorsView.disciplines}
-          </h2>
-          {hasPermission("create:role") && (
-            <DrawerFormDisciplines
-              componentTrigger={
-                <Button variant="bipc" className="text-white">
-                  <PlusIcon className="mr-1 h-4 w-4" />
-                  {t.collaboratorsView.newDiscipline}
-                </Button>
-              }
-              projectId={projectId}
-              projectUsers={collaborators}
-              roles={rolesNames}
-            />
-          )}
-        </div>
-
-        <div className="space-y-2">
-          {roles.map((discipline) => (
-            <div
-              key={discipline.id}
-              className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-600 rounded-lg"
-            >
-              <div className="flex items-center gap-4">
-                <div
-                  className="w-10 h-10 bg-gray-200 dark:bg-gray-600 rounded-full flex items-center justify-center text-sm font-medium text-gray-700 dark:text-gray-300"
-                  aria-label={discipline.name}
-                >
-                  {discipline.name.slice(0, 2)}
-                </div>
-                <div>
-                  <h3 className="text-h3 text-primary dark:text-gray-100">
-                    {discipline.name}
-                  </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {discipline.description || ""}
-                  </p>
-                </div>
-              </div>
-              {!discipline.is_protected && (
-                <div className="flex items-center gap-2">
-                  {hasPermission("delete:role") && (
-                    <ModalConfirmDelete
-                      componentTrigger={
-                        <SimpleTooltip
-                          content={t.disciplines.deleteDiscipline}
-                          side="bottom"
-                        >
-                          <Button
-                            variant="outline-destructive"
-                            size="icon-lg"
-                            aria-label={`${t.disciplines.deleteDiscipline} ${discipline.name}`}
-                          >
-                            {isDeletingDiscipline ? (
-                              <div className="h-4 w-4 animate-spin rounded-full border-1 border-secondary border-t-transparent" />
-                            ) : (
-                              <TrashIcon className="h-4 w-4" />
-                            )}
-                          </Button>
-                        </SimpleTooltip>
-                      }
-                      title={t.collaboratorsView.removeDiscipline}
-                      onConfirm={() => mutateDeleteDiscipline(discipline.id)}
-                    />
-                  )}
-                  {hasPermission("update:role") && (
-                    <DrawerFormDisciplines
-                      componentTrigger={
-                        <SimpleTooltip
-                          content={t.disciplines.editDiscipline}
-                          side="bottom"
-                        >
-                          <Button
-                            variant="outline-bipc"
-                            size="icon-lg"
-                            className="text-primary border-primary"
-                            aria-label={`Editar disciplina ${discipline.name}`}
-                          >
-                            <PencilIcon className="h-4 w-4" />
-                          </Button>
-                        </SimpleTooltip>
-                      }
-                      projectId={projectId}
-                      roleData={discipline}
-                      projectUsers={collaborators}
-                      roles={rolesNames}
-                    />
-                  )}
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-
       <div className="bg-white dark:bg-gray-800 rounded-lg dark:border-gray-700">
         <div className="flex justify-between items-center mb-3">
           <h2 className="text-h2 text-primary dark:text-gray-200">

--- a/web/frontend/src/components/layout/project/disciplines-view.tsx
+++ b/web/frontend/src/components/layout/project/disciplines-view.tsx
@@ -1,0 +1,164 @@
+import { Button } from "@/components/ui/button";
+import { PencilIcon, PlusIcon, TrashIcon } from "lucide-react";
+import DrawerFormDisciplines from "../drawer-form-disciplines";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getProjectCollaborators } from "@/actions/projectCollaborators/getProjectCollaborators";
+import ModalConfirmDelete from "../modal-confirm-delete";
+import { deleteDiscipline } from "@/actions/disciplines/deleteDiscipline";
+import { toast } from "sonner";
+import { queryClient } from "@/utils/queryClient";
+import { useProjectPermissions } from "@/hooks/useProjectPermissions";
+import { useTranslation } from "@/i18n";
+import { parseApiError } from "@/utils/parseApiError";
+import { SimpleTooltip } from "@/components/ui/simple-tooltip";
+
+const DisciplinesView = ({ projectId }: { projectId: string }) => {
+  const { hasPermission } = useProjectPermissions(projectId);
+  const { t } = useTranslation();
+
+  const { data: collaboratorsData, isLoading } = useQuery({
+    queryKey: ["project-collaborators", projectId],
+    queryFn: () => getProjectCollaborators(projectId),
+    staleTime: 0,
+    refetchOnMount: true,
+  });
+
+  const { mutate: mutateDeleteDiscipline, isPending: isDeletingDiscipline } =
+    useMutation({
+      mutationFn: (disciplineId: string) =>
+        deleteDiscipline(projectId, disciplineId),
+      onSuccess: () => {
+        toast.success(t.collaboratorsView.successRemoveDiscipline, {
+          duration: 5000,
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["project-collaborators", projectId],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["project-permissions", projectId],
+        });
+      },
+      onError: (error) => {
+        toast.error(t.collaboratorsView.errorRemoveDiscipline, {
+          description: parseApiError(error, t),
+          duration: 5000,
+        });
+      },
+    });
+
+  const collaborators = collaboratorsData?.data?.data?.collaborators || [];
+  const roles = collaboratorsData?.data?.data?.roles || [];
+  const rolesNames = roles.filter((r) => !r.is_protected).map((r) => r.name);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg dark:border-gray-700">
+        <div className="flex justify-between items-center mb-3">
+          <h2 className="text-h2 text-primary dark:text-gray-200">
+            {t.collaboratorsView.disciplines}
+          </h2>
+          {hasPermission("create:role") && (
+            <DrawerFormDisciplines
+              componentTrigger={
+                <Button variant="bipc" className="text-white">
+                  <PlusIcon className="mr-1 h-4 w-4" />
+                  {t.collaboratorsView.newDiscipline}
+                </Button>
+              }
+              projectId={projectId}
+              projectUsers={collaborators}
+              roles={rolesNames}
+            />
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {roles.map((discipline) => (
+            <div
+              key={discipline.id}
+              className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-600 rounded-lg"
+            >
+              <div className="flex items-center gap-4">
+                <div
+                  className="w-10 h-10 bg-gray-200 dark:bg-gray-600 rounded-full flex items-center justify-center text-sm font-medium text-gray-700 dark:text-gray-300"
+                  aria-label={discipline.name}
+                >
+                  {discipline.name.slice(0, 2)}
+                </div>
+                <div>
+                  <h3 className="text-h3 text-primary dark:text-gray-100">
+                    {discipline.name}
+                  </h3>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {discipline.description || ""}
+                  </p>
+                </div>
+              </div>
+              {!discipline.is_protected && (
+                <div className="flex items-center gap-2">
+                  {hasPermission("delete:role") && (
+                    <ModalConfirmDelete
+                      componentTrigger={
+                        <SimpleTooltip
+                          content={t.disciplines.deleteDiscipline}
+                          side="bottom"
+                        >
+                          <Button
+                            variant="outline-destructive"
+                            size="icon-lg"
+                            aria-label={`${t.disciplines.deleteDiscipline} ${discipline.name}`}
+                          >
+                            {isDeletingDiscipline ? (
+                              <div className="h-4 w-4 animate-spin rounded-full border-1 border-secondary border-t-transparent" />
+                            ) : (
+                              <TrashIcon className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </SimpleTooltip>
+                      }
+                      title={t.collaboratorsView.removeDiscipline}
+                      onConfirm={() => mutateDeleteDiscipline(discipline.id)}
+                    />
+                  )}
+                  {hasPermission("update:role") && (
+                    <DrawerFormDisciplines
+                      componentTrigger={
+                        <SimpleTooltip
+                          content={t.disciplines.editDiscipline}
+                          side="bottom"
+                        >
+                          <Button
+                            variant="outline-bipc"
+                            size="icon-lg"
+                            className="text-primary border-primary"
+                            aria-label={`Editar disciplina ${discipline.name}`}
+                          >
+                            <PencilIcon className="h-4 w-4" />
+                          </Button>
+                        </SimpleTooltip>
+                      }
+                      projectId={projectId}
+                      roleData={discipline}
+                      projectUsers={collaborators}
+                      roles={rolesNames}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DisciplinesView;

--- a/web/frontend/src/components/layout/project/index.ts
+++ b/web/frontend/src/components/layout/project/index.ts
@@ -1,2 +1,3 @@
 export { default as ProjectView } from "./project-view";
 export { default as CollaboratorsView } from "./collaborator-view";
+export { default as DisciplinesView } from "./disciplines-view";

--- a/web/frontend/src/components/ui/filter-tabs.tsx
+++ b/web/frontend/src/components/ui/filter-tabs.tsx
@@ -138,7 +138,7 @@ export function FilterTabs({
           )}
           {addTabAction && (
             <>
-              <div className="h-6 w-px bg-gray-shade-300 dark:bg-gray-shade-500 mx-1 shrink-0" />
+              <div className="h-6 w-px bg-gray-shade-300 dark:bg-gray-shade-500 mx-2 shrink-0" />
               {addTabAction}
             </>
           )}

--- a/web/frontend/src/components/ui/summary.tsx
+++ b/web/frontend/src/components/ui/summary.tsx
@@ -15,8 +15,8 @@ const Summary = () => {
       className={cn(
         "absolute bottom-0 right-0 bg-gray-50 dark:bg-sidebar w-full max-md:mx-auto max-md:left-0 transition-all z-49 border-t border-gray-200 dark:border-gray-700 shadow-lg",
         {
-          "h-[96vh] max-sm:h-[91vh]": isOpen && isExpanded,
-          "h-2/3": isOpen && !isExpanded,
+          "h-[100vh]": isOpen && isExpanded,
+          "h-4/5 min-[1710px]:h-2/3": isOpen && !isExpanded,
           "h-[50px]": !isOpen,
         },
       )}

--- a/web/frontend/src/i18n/translations/en.ts
+++ b/web/frontend/src/i18n/translations/en.ts
@@ -921,6 +921,7 @@ export const en: Translations = {
   projectView: {
     tabProject: "Project",
     tabCollaborators: "Collaborators",
+    tabDisciplines: "Disciplines",
     buildings: "Buildings",
     addBuilding: "Add Building",
     noBuildingsFound: "No buildings found",
@@ -1084,6 +1085,7 @@ export const en: Translations = {
       "The requested unit could not be found. It may have been removed or the link is incorrect.",
     backToProject: "Back to project",
     newDiscipline: "New discipline",
+    manageDisciplines: "Manage disciplines",
     createSimulations: "Manage simulations",
     selectDisciplineTooltip: "Select a discipline to manage simulations",
     noDisciplines: "No disciplines to display",

--- a/web/frontend/src/i18n/translations/pt-BR.ts
+++ b/web/frontend/src/i18n/translations/pt-BR.ts
@@ -925,6 +925,7 @@ export const ptBR = {
   projectView: {
     tabProject: "Empreendimento",
     tabCollaborators: "Colaboradores",
+    tabDisciplines: "Disciplinas",
     buildings: "Edificações",
     addBuilding: "Adicionar Edificação",
     noBuildingsFound: "Nenhuma edificação encontrada",
@@ -1094,6 +1095,7 @@ export const ptBR = {
       "Não foi possível encontrar a unidade solicitada. Ela pode ter sido removida ou o link está incorreto.",
     backToProject: "Voltar ao empreendimento",
     newDiscipline: "Nova disciplina",
+    manageDisciplines: "Gerenciar disciplinas",
     createSimulations: "Gerenciar simulações",
     selectDisciplineTooltip:
       "Selecione uma disciplina para gerenciar simulações",

--- a/web/frontend/src/routes/_private/new_projects/$projectId/index.tsx
+++ b/web/frontend/src/routes/_private/new_projects/$projectId/index.tsx
@@ -2,6 +2,7 @@ import { getProjectByUUID } from "@/actions/projects/getProject";
 import { getAllProjectsByUser } from "@/actions/projects/getProjects";
 import {
   CollaboratorsView,
+  DisciplinesView,
   DrawerFormUnit,
   ProjectView,
 } from "@/components/layout";
@@ -24,14 +25,14 @@ import { useTranslation } from "@/i18n";
 import { SimpleTooltip } from "@/components/ui/simple-tooltip";
 
 type ProjectSearch = {
-  tab?: "projeto" | "colaboradores";
+  tab?: "projeto" | "colaboradores" | "disciplinas";
 };
 
 export const Route = createFileRoute("/_private/new_projects/$projectId/")({
   component: RouteComponent,
   validateSearch: (search: Record<string, unknown>): ProjectSearch => {
     return {
-      tab: search.tab as "projeto" | "colaboradores",
+      tab: search.tab as "projeto" | "colaboradores" | "disciplinas",
     };
   },
 });
@@ -50,7 +51,11 @@ function RouteComponent() {
 
   const [selectedTab, setSelectedTab] = useState(t.projectView.tabProject);
   const { setSummaryContext } = useSummary();
-  const tabs = [t.projectView.tabProject, t.projectView.tabCollaborators];
+  const tabs = [
+    t.projectView.tabProject,
+    t.projectView.tabCollaborators,
+    t.projectView.tabDisciplines,
+  ];
 
   const { data: projectData } = useQuery({
     queryKey: ["projects"],
@@ -76,19 +81,29 @@ function RouteComponent() {
         co2_min: consumption?.co2_min ?? 0,
         energy_max: consumption?.energy_max ?? 0,
         energy_min: consumption?.energy_min ?? 0,
+        material: consumption?.material ?? 0,
       };
     });
 
   useEffect(() => {
     if (searchParams.tab === "colaboradores") {
       setSelectedTab(t.projectView.tabCollaborators);
+    } else if (searchParams.tab === "disciplinas") {
+      setSelectedTab(t.projectView.tabDisciplines);
     } else {
       setSelectedTab(t.projectView.tabProject);
     }
   }, [searchParams.tab, t]);
 
   const handleTabClick = (tab: string) => {
-    const tabParam = tab === t.projectView.tabCollaborators ? "colaboradores" : "projeto";
+    let tabParam: "projeto" | "colaboradores" | "disciplinas";
+    if (tab === t.projectView.tabCollaborators) {
+      tabParam = "colaboradores";
+    } else if (tab === t.projectView.tabDisciplines) {
+      tabParam = "disciplinas";
+    } else {
+      tabParam = "projeto";
+    }
 
     navigate({
       to: ".",
@@ -140,6 +155,9 @@ function RouteComponent() {
           projectId={projectId}
           projectName={projectData?.name}
         />
+      )}
+      {selectedTab === t.projectView.tabDisciplines && (
+        <DisciplinesView projectId={projectId} />
       )}
     </div>
   );

--- a/web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/index.tsx
+++ b/web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/index.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import Divider from "@/components/ui/divider";
 import { FilterTabs } from "@/components/ui/filter-tabs";
 import NotFoundList from "@/components/ui/not-found-list";
+import { SimpleTooltip } from "@/components/ui/simple-tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
@@ -37,7 +38,7 @@ import {
   useParams,
   useSearch,
 } from "@tanstack/react-router";
-import { Plus, SquareArrowOutUpRight, Upload } from "lucide-react";
+import { Plus, Settings, Upload } from "lucide-react";
 import { useEffect, useState } from "react";
 
 type TGroupedFloor = IConsumption &
@@ -457,25 +458,43 @@ function RouteComponent() {
                 onSubTabSelect={(tab) => onSelectedTabChange(tab)}
                 fullWidth
                 addTabAction={
-                  hasPermission("create:role") ? (
-                    <DrawerFormDisciplines
-                      componentTrigger={
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                  <div className="flex items-center gap-2">
+                    <SimpleTooltip
+                      content={t.unitView.manageDisciplines}
+                      side="bottom"
+                    >
+                      <Button
+                        variant="outline-bipc"
+                        size="icon"
+                        onClick={() =>
+                          navigate({
+                            to: "/new_projects/$projectId",
+                            params: { projectId },
+                            search: { tab: "disciplinas" },
+                          })
+                        }
+                      >
+                        <Settings />
+                      </Button>
+                    </SimpleTooltip>
+                    {hasPermission("create:role") && (
+                      <DrawerFormDisciplines
+                        componentTrigger={
+                          <SimpleTooltip
+                            content={t.unitView.newDiscipline}
+                            side="bottom"
+                          >
                             <Button variant="outline-bipc" size="icon">
                               <Plus />
                             </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {t.unitView.newDiscipline}
-                          </TooltipContent>
-                        </Tooltip>
-                      }
-                      projectId={projectId}
-                      unitId={unitId}
-                      roles={roleTabs}
-                    />
-                  ) : undefined
+                          </SimpleTooltip>
+                        }
+                        projectId={projectId}
+                        unitId={unitId}
+                        roles={roleTabs}
+                      />
+                    )}
+                  </div>
                 }
               />
               <Button variant="outline-bipc" size="icon-lg" disabled>


### PR DESCRIPTION
This pull request introduces a significant refactor to the handling of disciplines (project roles) in the frontend project management UI. The main change is the extraction of discipline management into its own dedicated view and tab, improving code organization and user experience. Additional improvements include updates to navigation, translations, and minor UI tweaks.

Key changes:

**Disciplines Management Refactor:**

* Extracted all discipline-related logic and UI from `CollaboratorsView` into a new `DisciplinesView` component, and removed discipline management code from `collaborator-view.tsx`. (`web/frontend/src/components/layout/project/collaborator-view.tsx`, `web/frontend/src/components/layout/project/disciplines-view.tsx`) [[1]](diffhunk://#diff-570c40b8a66145c3cf792eaa48e99a0883c9aecd49b8b83cf859af4a8fa3b64bL2-L10) [[2]](diffhunk://#diff-570c40b8a66145c3cf792eaa48e99a0883c9aecd49b8b83cf859af4a8fa3b64bL68-R75) [[3]](diffhunk://#diff-570c40b8a66145c3cf792eaa48e99a0883c9aecd49b8b83cf859af4a8fa3b64bL123-L124) [[4]](diffhunk://#diff-570c40b8a66145c3cf792eaa48e99a0883c9aecd49b8b83cf859af4a8fa3b64bL149-L246) [[5]](diffhunk://#diff-7f6a928ca86dcf9c6cedfd1b684fde74308cccdbdf12286df3a4b76326b0bc4fR1-R164)
* Registered the new `DisciplinesView` in the project layout index for easy import. (`web/frontend/src/components/layout/project/index.ts`)

**Navigation and Routing:**

* Added a new "Disciplines" tab to the project view, updated routing and search parameters to support the new tab, and ensured correct tab selection and navigation. (`web/frontend/src/routes/_private/new_projects/$projectId/index.tsx`) [[1]](diffhunk://#diff-364a10fc4b68483540abe8b07a1245cffb8291527c97d2445508bdcdb0248b13R5) [[2]](diffhunk://#diff-364a10fc4b68483540abe8b07a1245cffb8291527c97d2445508bdcdb0248b13L27-R35) [[3]](diffhunk://#diff-364a10fc4b68483540abe8b07a1245cffb8291527c97d2445508bdcdb0248b13L53-R58) [[4]](diffhunk://#diff-364a10fc4b68483540abe8b07a1245cffb8291527c97d2445508bdcdb0248b13R84-R106) [[5]](diffhunk://#diff-364a10fc4b68483540abe8b07a1245cffb8291527c97d2445508bdcdb0248b13R159-R161)
* Updated translation files to include the new "Disciplines" tab and related strings in both English and Portuguese. (`web/frontend/src/i18n/translations/en.ts`, `web/frontend/src/i18n/translations/pt-BR.ts`) [[1]](diffhunk://#diff-87f1463661ff74ec36b37475d3759e30beea831277c5d62efc96ffa2c462d08dR924) [[2]](diffhunk://#diff-87f1463661ff74ec36b37475d3759e30beea831277c5d62efc96ffa2c462d08dR1088) [[3]](diffhunk://#diff-cc3dd692fe604a06e5a222121106800d15e3a8c42e0b73720316649fe5d0d016R928) [[4]](diffhunk://#diff-cc3dd692fe604a06e5a222121106800d15e3a8c42e0b73720316649fe5d0d016R1098)

**UI/UX Improvements:**

* Adjusted the divider margin in `FilterTabs` for better spacing. (`web/frontend/src/components/ui/filter-tabs.tsx`)
* Tweaked the summary panel heights for improved display on large screens. (`web/frontend/src/components/ui/summary.tsx`)
* Minor icon and import cleanups in unit view. (`web/frontend/src/routes/_private/new_projects/$projectId/unit/$unitId/index.tsx`) [[1]](diffhunk://#diff-ca75aa47f56d5a1ba8cb36799433167ab5508591359fb0171f9a3ef96865941dR14) [[2]](diffhunk://#diff-ca75aa47f56d5a1ba8cb36799433167ab5508591359fb0171f9a3ef96865941dL40-R41)

These changes collectively improve the modularity of the codebase, clarify the separation between collaborators and disciplines, and enhance the user experience for managing project roles.