### PR TITLE
feat: start workflow with dispatch

### DIFF
--- a/.github/workflows/makefile_stage.yml
+++ b/.github/workflows/makefile_stage.yml
@@ -3,6 +3,7 @@ name: Deploy to Stage
 on:
   push:
     branches: [develop]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -14,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.26.1"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for staging deployments. The most important changes are:

Workflow triggers:

* Added support for manual workflow runs by including the `workflow_dispatch` trigger in `.github/workflows/makefile_stage.yml`.

Dependency updates:

* Updated the Go version used in the deployment job from `1.24` to `1.26.1` in `.github/workflows/makefile_stage.yml`.